### PR TITLE
upgrade: fix remove tmpPath error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sec change log
 
+1. 修复 `sec upgrade` 报错
+
+> 2026/05/14 20:29:24 ERROR replaceBinary failed to remove tmpPath tmpPath=/var/folders/d6/qd0kj49d5jv2bsyj3trs41mw0000gn/T/.sec-new-2675584278 error="remove /var/folders/d6/qd0kj49d5jv2bsyj3trs41mw0000gn/T/.sec-new-2675584278: no such file or directory"
+
 ### v0.2.16
 
 1. `sec kline` 终端绘制 K 线图显示行情数据

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -305,7 +305,11 @@ func replaceBinary(execPath string, data []byte) error {
 	}()
 
 	tmpPath := tmpFile.Name()
+	removeTmp := true // true defer 中删除 tmpPath
 	defer func() {
+		if !removeTmp {
+			return
+		}
 		removeErr := os.Remove(tmpPath)
 		if removeErr != nil {
 			slog.Error("replaceBinary failed to remove tmpPath", "tmpPath", tmpPath, "error", removeErr)
@@ -327,6 +331,9 @@ func replaceBinary(execPath string, data []byte) error {
 	if err := os.Rename(tmpPath, execPath); err != nil {
 		return copyFile(tmpPath, execPath)
 	}
+	// os.Rename 执行成功，tmpPath 已经被 mv 到 execPath
+	// tmpPath 不存在，defer 中不再执行删除目录操作
+	removeTmp = false
 
 	return nil
 }


### PR DESCRIPTION
1. 修复 `sec upgrade` 报错 `no such file or directory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error in the `sec upgrade` command that occurred when temporary files were unexpectedly removed during the upgrade process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alwqx/sec/pull/78)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->