### PR TITLE
Feat/balance sheet download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ go.work.sum
 
 # vscode
 sec.code-workspace
+
+*.pdf
+main.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# sec change log
+## sec change log
+
+### v0.3.2
+
+1. `sec balance-sheet` 支持下载报表信息
 
 ### v0.3.1
 

--- a/cmd/balancesheet/balance-sheet_test.go
+++ b/cmd/balancesheet/balance-sheet_test.go
@@ -1,0 +1,288 @@
+package balancesheet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alwqx/sec/provider/eastmoney"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCmd() *cobra.Command {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	return cmd
+}
+
+func TestFormatDate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2024-12-31 00:00:00", "2024-12-31"},
+		{"2024-03-15T08:30:00Z", "2024-03-15"},
+		{"2024-06-30", "2024-06-30"},
+		{"short", "short"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.want, formatDate(tt.input))
+		})
+	}
+}
+
+func TestFormatFieldValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiField string
+		value    interface{}
+		want     string
+	}{
+		{
+			name:     "nil value",
+			apiField: "ANY_FIELD",
+			value:    nil,
+			want:     "-",
+		},
+		{
+			name:     "report date with time",
+			apiField: "REPORT_DATE",
+			value:    "2024-12-31 00:00:00",
+			want:     "2024-12-31",
+		},
+		{
+			name:     "report date short",
+			apiField: "REPORT_DATE",
+			value:    "2024-12-31",
+			want:     "2024-12-31",
+		},
+		{
+			name:     "basic EPS",
+			apiField: "BASIC_EPS",
+			value:    5.66,
+			want:     "5.66",
+		},
+		{
+			name:     "diluted EPS",
+			apiField: "DILUTED_EPS",
+			value:    3.14159,
+			want:     "3.14",
+		},
+		{
+			name:     "large number uses HumanNum",
+			apiField: "TOTAL_ASSETS",
+			value:    337377000000.0,
+			want:     "3373.77亿",
+		},
+		{
+			name:     "small number uses HumanNum",
+			apiField: "TOTAL_PROFIT",
+			value:    500000.0,
+			want:     "50.00万",
+		},
+		{
+			name:     "string value",
+			apiField: "SECURITY_NAME_ABBR",
+			value:    "招商银行",
+			want:     "招商银行",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFieldValue(tt.apiField, tt.value)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPrintSummary(t *testing.T) {
+	t.Run("empty results", func(t *testing.T) {
+		cmd := newTestCmd()
+		printSummary(cmd, nil)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+		require.Contains(t, out, "无财务报表数据")
+	})
+
+	t.Run("empty items", func(t *testing.T) {
+		cmd := newTestCmd()
+		printSummary(cmd, []result{})
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+		require.Contains(t, out, "无财务报表数据")
+	})
+
+	t.Run("with data", func(t *testing.T) {
+		cmd := newTestCmd()
+		results := []result{
+			{
+				rt: eastmoney.ReportBalance,
+				items: []*eastmoney.FinancialReportItem{
+					{
+						ReportDate: "2024-12-31 00:00:00",
+						PeriodCode: eastmoney.PeriodAnnual,
+					},
+					{
+						ReportDate: "2024-09-30 00:00:00",
+						PeriodCode: eastmoney.PeriodQ3,
+					},
+				},
+			},
+			{
+				rt: eastmoney.ReportIncome,
+				items: []*eastmoney.FinancialReportItem{
+					{
+						ReportDate: "2024-12-31 00:00:00",
+						PeriodCode: eastmoney.PeriodAnnual,
+					},
+				},
+			},
+		}
+		printSummary(cmd, results)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+
+		require.Contains(t, out, "资产负债表")
+		require.Contains(t, out, "利润表")
+		require.Contains(t, out, "年报")
+		require.Contains(t, out, "2024-12-31")
+		require.Contains(t, out, "三季报")
+		require.Contains(t, out, "2024-09-30")
+	})
+}
+
+func TestPrintDetailed(t *testing.T) {
+	t.Run("empty fields", func(t *testing.T) {
+		cmd := newTestCmd()
+		r := result{
+			rt:    eastmoney.FinancialReportType("unknown"),
+			items: []*eastmoney.FinancialReportItem{{}},
+		}
+		printDetailed(cmd, r)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+		require.Contains(t, out, "无")
+		require.Contains(t, out, "数据")
+	})
+
+	t.Run("empty items", func(t *testing.T) {
+		cmd := newTestCmd()
+		r := result{
+			rt:    eastmoney.ReportBalance,
+			items: nil,
+		}
+		printDetailed(cmd, r)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+		require.Contains(t, out, "无")
+		require.Contains(t, out, "资产负债表")
+		require.Contains(t, out, "数据")
+	})
+
+	t.Run("with income data", func(t *testing.T) {
+		cmd := newTestCmd()
+		r := result{
+			rt: eastmoney.ReportIncome,
+			items: []*eastmoney.FinancialReportItem{
+				{
+					ReportDate:   "2024-12-31 00:00:00",
+					SecurityCode: "600036",
+					SecurityName: "招商银行",
+					Fields: map[string]interface{}{
+						"REPORT_DATE":          "2024-12-31 00:00:00",
+						"TOTAL_OPERATE_INCOME": 337377000000.0,
+						"OPERATE_PROFIT":       165623000000.0,
+						"TOTAL_PROFIT":         165623000000.0,
+						"INCOME_TAX":           15845000000.0,
+						"PARENT_NETPROFIT":     149778000000.0,
+						"BASIC_EPS":            5.66,
+					},
+				},
+			},
+		}
+		printDetailed(cmd, r)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+
+		require.Contains(t, out, "营业总收入")
+		require.Contains(t, out, "营业利润")
+		require.Contains(t, out, "归属母公司净利润")
+		require.Contains(t, out, "基本每股收益")
+		require.Contains(t, out, "3373.77亿")
+		require.Contains(t, out, "5.66")
+		require.Contains(t, out, "2024-12-31")
+	})
+
+	t.Run("with balance data", func(t *testing.T) {
+		cmd := newTestCmd()
+		r := result{
+			rt: eastmoney.ReportBalance,
+			items: []*eastmoney.FinancialReportItem{
+				{
+					ReportDate:   "2023-12-31 00:00:00",
+					SecurityCode: "000001",
+					SecurityName: "平安银行",
+					Fields: map[string]interface{}{
+						"REPORT_DATE":                "2023-12-31 00:00:00",
+						"TOTAL_ASSETS":               558000000000.0,
+						"TOTAL_LIABILITIES":          510000000000.0,
+						"TOTAL_EQUITY":               48000000000.0,
+						"TOTAL_CURRENT_ASSETS":       nil,
+						"TOTAL_NON_CURRENT_ASSETS":   nil,
+						"TOTAL_CURRENT_LIABILITIES":  nil,
+						"TOTAL_NON_CURRENT_LIABILITIES": nil,
+						"MONETARYFUNDS":              nil,
+					},
+				},
+			},
+		}
+		printDetailed(cmd, r)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+
+		require.Contains(t, out, "资产总计")
+		require.Contains(t, out, "负债合计")
+		require.Contains(t, out, "所有者权益")
+		require.Contains(t, out, "5580.00亿")
+	})
+
+	t.Run("with cashflow data", func(t *testing.T) {
+		cmd := newTestCmd()
+		r := result{
+			rt: eastmoney.ReportCashFlow,
+			items: []*eastmoney.FinancialReportItem{
+				{
+					ReportDate:   "2024-12-31 00:00:00",
+					SecurityCode: "600036",
+					SecurityName: "招商银行",
+					Fields: map[string]interface{}{
+						"REPORT_DATE":                "2024-12-31 00:00:00",
+						"NETCASH_OPERATE":            50000000000.0,
+						"NETCASH_INVEST":             -20000000000.0,
+						"NETCASH_FINANCE":            -10000000000.0,
+						"CASH_EQUIVALENTS_INCREASE":  20000000000.0,
+					},
+				},
+				{
+					ReportDate:   "2023-12-31 00:00:00",
+					SecurityCode: "600036",
+					SecurityName: "招商银行",
+					Fields: map[string]interface{}{
+						"REPORT_DATE":                "2023-12-31 00:00:00",
+						"NETCASH_OPERATE":            45000000000.0,
+						"NETCASH_INVEST":             -15000000000.0,
+						"NETCASH_FINANCE":            -8000000000.0,
+						"CASH_EQUIVALENTS_INCREASE":  22000000000.0,
+					},
+				},
+			},
+		}
+		printDetailed(cmd, r)
+		out := cmd.OutOrStdout().(*bytes.Buffer).String()
+
+		require.Contains(t, out, "经营活动现金流")
+		require.Contains(t, out, "投资活动现金流")
+		require.Contains(t, out, "现金净增加额")
+			require.Contains(t, out, "500.00亿")
+			require.Contains(t, out, "2024-12-31")
+			require.Contains(t, out, "2023-12-31")
+	})
+}

--- a/cmd/balancesheet/download.go
+++ b/cmd/balancesheet/download.go
@@ -1,0 +1,222 @@
+package balancesheet
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alwqx/sec/provider/cninfo"
+	"github.com/alwqx/sec/provider/sina"
+	"github.com/alwqx/sec/types"
+	"github.com/spf13/cobra"
+)
+
+func NewBalanceSheetDownloadCLI() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "balance-sheet-download",
+		Aliases:       []string{"bsd"},
+		Short:         "Download annual report PDFs from CNINFO",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+		},
+		RunE: BalanceSheetDownloadHandler,
+	}
+	cmd.Flags().BoolP("debug", "D", false, "Enable debug mode")
+	cmd.Flags().StringP("year", "y", "", "Year, e.g. 2024")
+	cmd.Flags().String("start-year", "", "Start year for range download, e.g. 2024")
+	cmd.Flags().String("end-year", "", "End year for range download, e.g. 2026")
+	cmd.Flags().StringP("output-dir", "o", ".", "Directory to save downloaded PDFs")
+
+	return cmd
+}
+
+func BalanceSheetDownloadHandler(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("args of command should be one")
+	}
+
+	key := args[0]
+	secs := sina.Search(cmd.Context(), key)
+	if len(secs) == 0 {
+		slog.Info("search no sec", "code", key)
+		return nil
+	}
+	sec := secs[0]
+
+	// Look up orgId from CNINFO
+	orgID, cnName, err := cninfo.LookupOrgID(cmd.Context(), sec.Code)
+	if err != nil {
+		return fmt.Errorf("查找CNINFO证券代码失败: %w (仅支持A股，代码: %s)", err, sec.Code)
+	}
+
+	stockParam := fmt.Sprintf("%s,%s", sec.Code, orgID)
+
+	// Determine year range
+	var startDate, endDate string
+	yearStr, _ := cmd.Flags().GetString("year")
+	startYearStr, _ := cmd.Flags().GetString("start-year")
+	endYearStr, _ := cmd.Flags().GetString("end-year")
+	startDate, endDate, err = genStartEndDate(yearStr, startYearStr, endYearStr)
+	if err != nil {
+		slog.ErrorContext(cmd.Context(), "genStartEndDate", "error", err)
+		return err
+	}
+
+	slog.DebugContext(cmd.Context(), "downloadHandler", "startDate", startDate, "endDate", endDate)
+
+	// Query CNINFO for annual reports
+	req := &cninfo.QueryRequest{
+		StockCode: stockParam,
+		Category:  cninfo.CategoryAnnual,
+		StartDate: startDate,
+		EndDate:   endDate,
+		PageNum:   1,
+		PageSize:  30,
+	}
+	resp, err := cninfo.QueryAnnouncements(cmd.Context(), req)
+	if err != nil {
+		return fmt.Errorf("查询年报公告失败: %w", err)
+	}
+
+	if resp == nil || len(resp.Data) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "未找到 %s(%s) 的年报公告\n", sec.Code, cnName)
+		return nil
+	}
+
+	// Filter valid PDFs (exclude corrections, summaries, English versions)
+	var validPDFs []*cninfo.Announcement
+	for _, a := range resp.Data {
+		if a.ExistFlag != 0 || a.InvalidationFlag != 0 {
+			continue
+		}
+		title := a.Title
+		skip := false
+		for _, kw := range []string{"摘要", "英文", "已取消", "更正", "修订"} {
+			if strings.Contains(title, kw) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		validPDFs = append(validPDFs, a)
+	}
+
+	if len(validPDFs) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "未找到 %s(%s) 的可用年报PDF\n", sec.Code, cnName)
+		return nil
+	}
+
+	// Show found announcements
+	fmt.Fprintf(cmd.OutOrStdout(), "\n证券代码: %s  证券名称: %s\n", sec.ExCode, cnName)
+	fmt.Fprintf(cmd.OutOrStdout(), "找到 %d 份年报公告:\n\n", len(validPDFs))
+
+	summaryHeaders := []string{"公告标题", "公告日期", "文件大小"}
+	summaryData := make([][]string, 0, len(validPDFs))
+	for _, a := range validPDFs {
+		t := time.Unix(a.Time/1000, 0).Format("2006-01-02")
+		size := types.HumanNum(float64(a.AdjunctSize))
+		summaryData = append(summaryData, []string{a.Title, t, size})
+	}
+	renderTable(cmd, summaryHeaders, summaryData)
+
+	// Download each PDF
+	outputDir, _ := cmd.Flags().GetString("output-dir")
+	fmt.Fprintf(cmd.OutOrStdout(), "\n下载年报PDF到 %s ...\n\n", outputDir)
+
+	for _, a := range validPDFs {
+		year := extractYear(a.Title)
+		fileName := fmt.Sprintf("%s_%s_%s_年报.pdf", sec.Code, cnName, year)
+		destPath := filepath.Join(outputDir, fileName)
+
+		fmt.Fprintf(cmd.OutOrStdout(), "  下载: %s", a.Title)
+		if err := cninfo.DownloadPDF(cmd.Context(), a.AdjunctURL, destPath); err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), " ... 失败: %v\n", err)
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), " ... 完成 (%s)\n", types.HumanNum(float64(a.AdjunctSize)))
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout())
+	return nil
+}
+
+// extractYear tries to extract a year string from an announcement title.
+func extractYear(title string) string {
+	for i := 0; i < len(title)-3; i++ {
+		if title[i] >= '0' && title[i] <= '9' &&
+			title[i+1] >= '0' && title[i+1] <= '9' &&
+			title[i+2] >= '0' && title[i+2] <= '9' &&
+			title[i+3] >= '0' && title[i+3] <= '9' {
+			return title[i : i+4]
+		}
+	}
+	return "unknown"
+}
+
+// genStartEndDate 生成查询报表的时间范围
+func genStartEndDate(yearStr, startYearStr, endYearStr string) (startDate string, endDate string, err error) {
+	var year, startYear, endYear int
+	// 优先判断 year
+	if yearStr != "" {
+		year, err = strconv.Atoi(yearStr)
+		if err != nil {
+			return
+		}
+		startDate = fmt.Sprintf("%d-01-01", year)
+		endDate = fmt.Sprintf("%d-12-31", year)
+
+		return
+	}
+
+	if startYearStr != "" {
+		startYear, err = strconv.Atoi(startYearStr)
+		if err != nil {
+			slog.Error("genStartEndDate", "start-year", startYearStr, "error", err)
+			return
+		}
+		if endYearStr != "" {
+			endYear, err = strconv.Atoi(endYearStr)
+			if err != nil {
+				slog.Error("genStartEndDate", "end-year", endYearStr, "error", err)
+				return
+			}
+		} else {
+			endYear = time.Now().Year()
+		}
+
+		// check year range
+		if startYear > endYear {
+			err = fmt.Errorf("invalid year range, start=%s, end=%s", startYearStr, endYearStr)
+		} else {
+			startDate = fmt.Sprintf("%d-01-01", startYear)
+			endDate = fmt.Sprintf("%d-12-31", endYear)
+		}
+
+		return
+	}
+
+	curYear := time.Now().Year()
+	if endYearStr != "" {
+		endYear, err = strconv.Atoi(endYearStr)
+		if err != nil {
+			slog.Error("genStartEndDate", "end-year", endYearStr, "error", err)
+		} else {
+			startDate = fmt.Sprintf("%d-01-01", endYear)
+			endDate = fmt.Sprintf("%d-12-31", endYear)
+		}
+	} else {
+		// Default: current year
+		startDate = fmt.Sprintf("%d-01-01", curYear)
+		endDate = fmt.Sprintf("%d-12-31", curYear)
+	}
+
+	return
+}

--- a/cmd/balancesheet/download_test.go
+++ b/cmd/balancesheet/download_test.go
@@ -1,0 +1,112 @@
+package balancesheet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractYear(t *testing.T) {
+	testCases := []struct {
+		title string
+		want  string
+	}{
+		{"2024年年度报告", "2024"},
+		{"2024年年度报告（更新后）", "2024"},
+		{"2023年年度报告全文", "2023"},
+		{"2022年年度报告（英文版）", "2022"},
+		{"招商银行股份有限公司2021年年度报告", "2021"},
+		{"2020年年度报告摘要", "2020"},
+		{"无年份的公告标题", "unknown"},
+		{"年份19年报告", "unknown"},   // less than 4 digits
+		{"", "unknown"},          // empty title
+		{"abc2025def", "2025"},   // year embedded in text
+		{"20001231年度报告", "2000"}, // first 4-digit match wins
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			got := extractYear(tc.title)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGenStartEndDate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		yearStr      string
+		startYearStr string
+		endYearStr   string
+		wantStart    string
+		wantEnd      string
+		wantErr      bool
+	}{
+		{
+			name:      "single year",
+			yearStr:   "2024",
+			wantStart: "2024-01-01",
+			wantEnd:   "2024-12-31",
+		},
+		{
+			name:         "year range",
+			startYearStr: "2020",
+			endYearStr:   "2023",
+			wantStart:    "2020-01-01",
+			wantEnd:      "2023-12-31",
+		},
+		{
+			name:         "invalid year range",
+			startYearStr: "2029",
+			endYearStr:   "2023",
+			wantErr:      true,
+		},
+		{
+			name:    "invalid year",
+			yearStr: "abc",
+			wantErr: true,
+		},
+		{
+			name:         "invalid start-year",
+			startYearStr: "xyz",
+			wantErr:      true,
+		},
+		{
+			name:         "valid start-year invalid end-year",
+			startYearStr: "2020",
+			endYearStr:   "abc",
+			wantErr:      true,
+		},
+		{
+			name:      "empty: defaults to current year",
+			wantStart: "",
+			wantEnd:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, err := genStartEndDate(tc.yearStr, tc.startYearStr, tc.endYearStr)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.wantStart != "" {
+				require.Equal(t, tc.wantStart, start)
+			} else {
+				// empty args defaults to current year, just check format
+				require.Regexp(t, `^\d{4}-01-01$`, start)
+			}
+			if tc.wantEnd != "" {
+				require.Equal(t, tc.wantEnd, end)
+			} else {
+				require.Regexp(t, `^\d{4}-12-31$`, end)
+			}
+
+			// Verify start < end
+			require.True(t, start <= end, "start %s should be <= end %s", start, end)
+		})
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,6 +65,7 @@ func NewCLI() *cobra.Command {
 	rootCmd.AddCommand(
 		searchCmd, infoCmd,
 		balancesheet.NewBalanceSheetCLI(),
+		balancesheet.NewBalanceSheetDownloadCLI(),
 		bond.NewBondCLI(), bond.NewBondHistoryCLI(),
 		kline.NewKLineCLI(),
 		quote.NewQuoteCLI(), quote.NewQuoteHistoryCLI(),

--- a/docs/balance-sheet.md
+++ b/docs/balance-sheet.md
@@ -173,9 +173,86 @@ Go 侧处理：正则 `/jQuery.*?\((.*)\);?$/s` 提取中间 JSON，再 `json.Un
 | **JSON**         | 原始结构化数据                 | `encoding/json`（标准库） |
 | **Excel (XLSX)** | 原生 Excel 格式                | `excelize` 第三方库       |
 
-### 方式二：原始 PDF 公告（未来可扩展）
+### 方式二：原始 PDF 年报 — 巨潮资讯网 CNINFO（已实现）
 
-上市公司正式的财务报告 PDF 文件发布在**巨潮资讯网**（`cninfo.com.cn`），可通过爬取获取。此方案复杂度高，暂不纳入本次实现范围。
+巨潮资讯网（`cninfo.com.cn`）是中国证监会指定的法定信息披露平台，覆盖沪深北三市全部 A 股上市公司。
+
+#### CNINFO API 端点
+
+| 端点                                                  | 方法 | 说明                               |
+| ----------------------------------------------------- | ---- | ---------------------------------- |
+| `https://www.cninfo.com.cn/new/data/szse_stock.json`  | GET  | 获取全部 A 股列表（含 orgId 映射） |
+| `https://www.cninfo.com.cn/new/hisAnnouncement/query` | POST | 历史公告查询                       |
+| `http://static.cninfo.com.cn/{adjunctUrl}`            | GET  | PDF 文件下载（公开 CDN）           |
+
+#### 认证要求
+
+- **无需认证**，无需 Cookie 或 Token
+- 公告查询需要设置 `X-Requested-With: XMLHttpRequest` 和 `Referer` 头
+- PDF 下载无任何限制
+
+#### 公告分类代码
+
+| 代码                  | 含义   |
+| --------------------- | ------ |
+| `category_ndbg_szsh`  | 年报   |
+| `category_bndbg_szsh` | 半年报 |
+| `category_yjdbg_szsh` | 一季报 |
+| `category_sjdbg_szsh` | 三季报 |
+
+#### 查询参数（POST body，form-urlencoded）
+
+| 参数        | 必填 | 说明                      | 示例                    |
+| ----------- | ---- | ------------------------- | ----------------------- |
+| `pageNum`   | 是   | 页码                      | `1`                     |
+| `pageSize`  | 是   | 每页条数                  | `30`                    |
+| `column`    | 是   | 交易所：`szse`/`sse`/`bj` | `sse`                   |
+| `tabName`   | 是   | 固定为 `fulltext`         | `fulltext`              |
+| `plate`     | 是   | 板块：`sz`/`sh`/`bj`      | `sh`                    |
+| `stock`     | 否   | 格式 `{code},{orgId}`     | `600036,gssh0600036`    |
+| `category`  | 否   | 公告分类                  | `category_ndbg_szsh`    |
+| `seDate`    | 否   | 日期范围                  | `2024-01-01~2024-04-30` |
+| `searchkey` | 否   | 全文搜索关键词            | `年度报告`              |
+
+#### stock → orgId 映射
+
+通过 `szse_stock.json` 获取映射表（约 500KB，缓存 24 小时）：
+
+| 交易所       | 代码前缀 | orgId 示例               |
+| ------------ | -------- | ------------------------ |
+| 深交所主板   | `00`     | `000001` → `gssz0000001` |
+| 深交所创业板 | `30`     | `300750` → `gssz0300750` |
+| 上交所主板   | `60`     | `600036` → `gssh0600036` |
+| 上交所科创板 | `68`     | `688001` → `gssh0688001` |
+
+#### PDF 文件命名规则
+
+PDF 保存在 CNINFO 的静态 CDN 上，URL 格式：
+
+```
+http://static.cninfo.com.cn/{adjunctUrl}
+```
+
+其中 `adjunctUrl` 由公告查询 API 返回（如 `finalpage/2024-03-29/1205958883.PDF`）。
+
+#### 过滤无效公告
+
+API 返回结果可能包含摘要、英文版、更正公告等，需要通过以下条件过滤：
+
+- `existFlag == 1`（文件存在）
+- `invalidationFlag == 0`（未被撤销）
+- 标题不含：`摘要`、`英文`、`已取消`、`更正`、`修订`
+
+#### 其他官方平台对比
+
+| 平台                | 覆盖范围        | API 格式             | 认证                      | 推荐度 |
+| ------------------- | --------------- | -------------------- | ------------------------- | ------ |
+| **CNINFO （巨潮）** | 沪深北全部 A 股 | form-urlencoded POST | 无                        | ★★★★★  |
+| SZSE （深交所）     | 仅深市          | JSON POST            | 无（需 `X-Request-Type`） | ★★★    |
+| SSE （上交所）      | 仅沪市          | GET + JSONP          | 无（需 `Referer`）        | ★★     |
+| NEEQ （新三板）     | 新三板          | POST + JSONP         | 无                        | ★★     |
+
+**结论：CNINFO 是唯一能一站式覆盖沪深北三市的官方平台，API 简洁、无认证、PDF 直链。**
 
 ---
 
@@ -183,43 +260,56 @@ Go 侧处理：正则 `/jQuery.*?\((.*)\);?$/s` 提取中间 JSON，再 `json.Un
 
 ### 命令设计
 
-新增 `sec balance-sheet`（别名 `sec bs`）命令：
+新增两个命令：
+
+**`sec balance-sheet`（别名 `sec bs`）** — 结构化财务数据查询：
 
 ```bash
-# 列出所有可用财务报表（默认近 5 年年报+最新季报）
+# 列出所有可用财务报表
 sec bs 600036
 
 # 指定报表类型
 sec bs 600036 --type balance    # 资产负债表
-sec bs 600036 --type income      # 利润表
-sec bs 600036 --type cashflow    # 现金流量表
+sec bs 600036 --type income     # 利润表
+sec bs 600036 --type cashflow   # 现金流量表
 
 # 指定报告期
-sec bs 600036 --period annual    # 仅年报
-sec bs 600036 --period all       # 全部报告期
-
-# 指定年份范围
-sec bs 600036 --from 2020 --to 2025
-
-# 下载/导出（输出到表格）
-sec bs 600036 --type balance --period annual
+sec bs 600036 --period annual   # 仅年报
 
 # 导出到文件
 sec bs 600036 --type income --output report.csv
 sec bs 600036 --type balance --output report.json
-sec bs 600036 --type cashflow --output report.xlsx
+```
+
+**`sec balance-sheet-download`（别名 `sec bsd`）** — 从巨潮资讯网下载原始年报 PDF：
+
+```bash
+# 下载当年年报 PDF
+sec bsd 600036
+
+# 下载指定年份
+sec bsd 600036 --year 2024
+
+# 下载年份范围
+sec bsd 600036 --start-year 2020 --end-year 2023
+
+# 指定输出目录
+sec bsd 600036 -y 2024 -o ./reports
 ```
 
 ### 架构设计
 
 ```
-cmd/balancesheet/bs.go          CLI 命令处理器
+sec bs (balance-sheet.go)
     ↓
-provider/eastmoney/bs.go        财务报表数据获取（复用 datacenter-web API）
+provider/eastmoney/balancesheet.go   东方财富 datacenter-web API
+    → 终端表格 / CSV / JSON 输出
+
+sec bsd (download.go)
     ↓
-provider/eastmoney/types.go     新增财务报表相关类型定义
-    ↓
-输出：tablewriter 终端表格 或 CSV/JSON/XLSX 文件
+provider/cninfo/cninfo.go            巨潮资讯网 CNINFO
+    → 公告查询 + PDF 下载到本地
+    → 股票列表缓存 (~/.sec/cache/cninfo_stocks.json)
 ```
 
 ### 文件结构
@@ -232,8 +322,16 @@ provider/eastmoney/
 └── balancesheet_test.go  # 单元测试
 
 cmd/balancesheet/
-├── bs.go                 # sec bs / sec balance-sheet 命令
-└── bs_test.go            # CLI 测试
+├── balance-sheet.go      # sec bs — 结构化财务数据查询 + CSV/JSON 导出
+├── balance-sheet_test.go # formatFieldValue / formatDate / printSummary / printDetailed 测试
+├── download.go           # sec bsd — CNINFO 年报 PDF 下载
+└── download_test.go      # extractYear / genStartEndDate 测试
+
+provider/cninfo/
+└── cninfo.go             # CNINFO 公告查询 + PDF 下载
+
+utils/
+└── utils.go              # SecDir() — ~/.sec/ 统一配置缓存目录
 ```
 
 ### 核心类型设计
@@ -287,43 +385,37 @@ type GetFinancialReportResp struct {
 
 3. **数值格式化**：财务数据以"元"为单位（如 `146695000000` = 1466.95 亿），复用 `types.HumanNum()` 进行格式化
 
-4. **下载实现**：
-   - CSV：`encoding/csv` 直接输出，UTF-8 BOM 头保证 Excel 兼容
-   - JSON：`json.MarshalIndent` 格式化输出
-   - XLSX：可选，如需支持则引入 `github.com/xuri/excelize/v2`
+4. **CNINFO PDF 下载**：`sec bsd` 命令查询巨潮资讯网公告列表 → 过滤有效 PDF（排除摘要/英文/更正） → 下载到本地
 
-5. **环境适配**：`--output` 指定文件路径，默认输出到终端（tablewriter 表格）
+5. **缓存机制**：CNINFO 股票列表缓存到 `~/.sec/cache/cninfo_stocks.json`（24h 有效期），通过 `utils.SecDir("cache")` 管理路径
+
+6. **环境适配**：`--output` 指定 CSV/JSON 文件路径，默认输出到终端（tablewriter 表格）；PDF 下载默认输出到当前目录
 
 ### 与现有代码的复用
 
-| 功能       | 复用来源                                                         |
-| ---------- | ---------------------------------------------------------------- |
-| HTTP 请求  | `utils.MakeRequest(ctx, http.MethodGet, url, nil, nil, timeout)` |
-| 证券搜索   | `sina.Search(ctx, key)`                                          |
-| 大数格式化 | `types.HumanNum(value)`                                          |
-| 终端表格   | `github.com/olekukonko/tablewriter`（已有依赖）                  |
-| 日期解析   | `time.Parse(utils.LayoutYYMMDD, ...)`                            |
-| 交易所映射 | `sina.BasicSecurity.ExChange` → 已在 `kline.go` 中使用           |
+| 功能 | 复用来源 |
+|---|---|
+| HTTP 请求 | `utils.MakeRequest(ctx, http.MethodGet, url, nil, nil, timeout)` |
+| 证券搜索 | `sina.Search(ctx, key)` |
+| 大数格式化 | `types.HumanNum(value)` |
+| 终端表格 | `github.com/olekukonko/tablewriter`（已有依赖） |
+| 配置目录 | `utils.SecDir("cache")` → `~/.sec/cache/` |
 
-### 实现步骤
+### 已实现的 Phase
 
-1. **Phase 1：数据层** (`provider/eastmoney/balancesheet.go`)
-   - 实现 `GetFinancialStatements(ctx, req)` 函数
+1. **Phase 1：数据层**
+   - `provider/eastmoney/balancesheet.go` — 东方财富结构化财务数据
+   - `provider/cninfo/cninfo.go` — 巨潮资讯网公告查询 + PDF 下载
    - JSONP 解析、类型定义、错误处理
-   - 单元测试
+   - 单元测试完成
 
-2. **Phase 2：CLI 命令** (`cmd/balancesheet/bs.go`)
-   - `sec balance-sheet` / `sec bs` 命令
-   - 默认表格输出（终端）
-   - `--output` 导出到 CSV/JSON
+2. **Phase 2：CLI 命令**
+   - `sec bs` — 终端表格 + CSV/JSON 导出
+   - `sec bsd` — 年报 PDF 下载（`--year` / `--start-year` / `--end-year`）
+   - 单元测试完成（formatFieldValue / formatDate / printSummary / printDetailed / extractYear / genStartEndDate）
 
-3. **Phase 3：下载功能**
-   - `--output report.csv` CSV 导出
-   - `--output report.json` JSON 导出
-   - Excel BOM 头处理
-
-4. **Phase 4：文档**
-   - `docs/balance-sheet.md`（本文件）
+3. **Phase 3：基础设施**
+   - `utils.SecDir()` — `~/.sec/` 统一配置缓存目录
 
 ## 终端输出示例
 

--- a/provider/cninfo/cninfo.go
+++ b/provider/cninfo/cninfo.go
@@ -1,0 +1,324 @@
+// Package cninfo provides access to the CNINFO (巨潮资讯网) official disclosure platform.
+// CNINFO is the CSRC-designated platform for listed company announcements in China,
+// covering all A-share stocks across Shanghai, Shenzhen, and Beijing exchanges.
+package cninfo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alwqx/sec/utils"
+)
+
+const (
+	stockListURL = "https://www.cninfo.com.cn/new/data/szse_stock.json"
+	queryURL     = "https://www.cninfo.com.cn/new/hisAnnouncement/query"
+	pdfBaseURL   = "http://static.cninfo.com.cn"
+
+	// Announcement category codes
+	CategoryAnnual   = "category_ndbg_szsh"  // 年报
+	CategoryHalfYear = "category_bndbg_szsh" // 半年报
+	CategoryQ1       = "category_yjdbg_szsh" // 一季报
+	CategoryQ3       = "category_sjdbg_szsh" // 三季报
+)
+
+// StockInfo holds a stock entry from the CNINFO stock list.
+type StockInfo struct {
+	Code     string `json:"code"`
+	OrgID    string `json:"orgId"`
+	Name     string `json:"zwjc"`
+	Category string `json:"category"`
+}
+
+// Announcement represents a single disclosure announcement.
+type Announcement struct {
+	ID               string `json:"announcementId"`
+	Title            string `json:"announcementTitle"`
+	Time             int64  `json:"announcementTime"`
+	AdjunctURL       string `json:"adjunctUrl"`
+	AdjunctSize      int64  `json:"adjunctSize"`
+	AdjunctType      string `json:"adjunctType"`
+	SecCode          string `json:"secCode"`
+	SecName          string `json:"secName"`
+	OrgID            string `json:"orgId"`
+	TypeName         string `json:"announcementTypeName"`
+	ExistFlag        int    `json:"existFlag"`
+	InvalidationFlag int    `json:"invalidationFlag"`
+}
+
+// QueryRequest holds parameters for querying announcements.
+type QueryRequest struct {
+	StockCode string // "{code},{orgId}" format
+	Category  string // announcement category code
+	StartDate string // "YYYY-MM-DD"
+	EndDate   string // "YYYY-MM-DD"
+	SearchKey string // full-text search keyword
+	PageNum   int
+	PageSize  int
+}
+
+// QueryResponse wraps the CNINFO API response.
+type QueryResponse struct {
+	Total      int             `json:"totalAnnouncement"`
+	TotalPages int             `json:"totalpages"`
+	HasMore    bool            `json:"hasMore"`
+	Data       []*Announcement `json:"announcements"`
+}
+
+// columnForCode determines the exchange column parameter from a stock code.
+func columnForCode(code string) string {
+	if len(code) < 2 {
+		return "szse"
+	}
+	switch code[:2] {
+	case "60", "68":
+		return "sse"
+	case "83", "87", "43", "40":
+		return "bj"
+	default:
+		return "szse"
+	}
+}
+
+// plateForCode determines the plate parameter (market segment).
+func plateForCode(code string) string {
+	if len(code) < 2 {
+		return "sz;sh"
+	}
+	switch code[:2] {
+	case "60", "68":
+		return "sh"
+	case "83", "87", "43", "40":
+		return "bj"
+	default:
+		return "sz"
+	}
+}
+
+// stockListCachePath returns the path for caching the stock list JSON.
+// Uses ~/.sec/cache/ directory, falling back to os.TempDir if unavailable.
+func stockListCachePath() (path string) {
+	dir, err := utils.SecDir("cache")
+	if err != nil {
+		path = filepath.Join(os.TempDir(), "sec_cninfo_stocks.json")
+		slog.Warn("stockListCachePath err and use tmp dir", "error", err, "tmp_path", path)
+	} else {
+		path = filepath.Join(dir, "cninfo_stocks.json")
+	}
+
+	return
+}
+
+// loadStockListCache tries to load cached stock list data.
+func loadStockListCache() ([]byte, bool) {
+	path := stockListCachePath()
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false
+	}
+	// Cache valid for 24 hours
+	if time.Since(info.ModTime()) > 24*time.Hour {
+		return nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// saveStockListCache saves stock list data to cache.
+func saveStockListCache(data []byte) {
+	path := stockListCachePath()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		slog.Warn("failed to cache stock list", "error", err)
+	}
+}
+
+// GetStockList fetches the full stock-to-orgId mapping from CNINFO.
+func GetStockList(ctx context.Context) ([]*StockInfo, error) {
+	// Try cache first
+	if cached, ok := loadStockListCache(); ok {
+		var payload struct {
+			StockList []*StockInfo `json:"stockList"`
+		}
+		err := json.Unmarshal(cached, &payload)
+		if err == nil {
+			slog.DebugContext(ctx, "GetStockList get cache")
+			return payload.StockList, nil
+		} else {
+			slog.ErrorContext(ctx, "GetStockList failed json.Unmarshal cache", "error", err)
+		}
+	}
+
+	resp, err := utils.MakeRequest(ctx, http.MethodGet, stockListURL, nil, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("fetch stock list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	saveStockListCache(body)
+
+	var stockList struct {
+		StockList []*StockInfo `json:"stockList"`
+	}
+	if err := json.Unmarshal(body, &stockList); err != nil {
+		return nil, fmt.Errorf("parse stock list: %w", err)
+	}
+
+	return stockList.StockList, nil
+}
+
+// LookupOrgID finds the orgId for a given stock code.
+func LookupOrgID(ctx context.Context, code string) (string, string, error) {
+	stocks, err := GetStockList(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "LookupOrgID", "error", err)
+		return "", "", err
+	}
+	for _, s := range stocks {
+		if s.Code == code {
+			return s.OrgID, s.Name, nil
+		}
+	}
+	return "", "", fmt.Errorf("stock code %s not found in CNINFO stock list", code)
+}
+
+// QueryAnnouncements queries CNINFO for announcements matching the request.
+func QueryAnnouncements(ctx context.Context, req *QueryRequest) (*QueryResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("req is nil")
+	}
+
+	pageNum := req.PageNum
+	if pageNum <= 0 {
+		pageNum = 1
+	}
+	pageSize := req.PageSize
+	if pageSize <= 0 {
+		pageSize = 30
+	}
+
+	// Determine column and plate from stock code
+	codeOnly := req.StockCode
+	if idx := strings.Index(codeOnly, ","); idx > 0 {
+		codeOnly = codeOnly[:idx]
+	}
+	column := columnForCode(codeOnly)
+
+	form := url.Values{}
+	form.Set("pageNum", strconv.Itoa(pageNum))
+	form.Set("pageSize", strconv.Itoa(pageSize))
+	form.Set("column", column)
+	form.Set("tabName", "fulltext")
+	// form.Set("sortName", "announcementTime")
+	// form.Set("sortType", "desc")
+	form.Set("isHLtitle", "true")
+
+	if req.StockCode != "" {
+		form.Set("stock", req.StockCode)
+	}
+	if req.Category != "" {
+		form.Set("category", req.Category)
+	}
+	if req.StartDate != "" && req.EndDate != "" {
+		form.Set("seDate", req.StartDate+"~"+req.EndDate)
+	}
+	if req.SearchKey != "" {
+		form.Set("searchkey", req.SearchKey)
+	}
+
+	// CNINFO requires specific headers
+	headers := http.Header{}
+	headers.Set("X-Requested-With", "XMLHttpRequest")
+	headers.Set("Referer", "https://www.cninfo.com.cn/new/commonUrl/pageOfSearch?url=disclosure/list/search")
+	headers.Set("Accept", "application/json, text/javascript, */*; q=0.01")
+
+	// Send parameters as query string in a POST request
+	reqURL := queryURL + "?" + form.Encode()
+
+	slog.DebugContext(ctx, "QueryAnnouncements", "reqURL", reqURL)
+
+	resp, err := utils.MakeRequest(ctx, http.MethodPost, reqURL, headers, nil, 0)
+	if err != nil {
+		slog.ErrorContext(ctx, "QueryAnnouncements failed request", "url", reqURL)
+		return nil, fmt.Errorf("query announcements: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.ErrorContext(ctx, "QueryAnnouncements http status code", "code", resp.StatusCode, "body", string(body))
+		return nil, fmt.Errorf("invalid status code %d", resp.StatusCode)
+	}
+
+	var qr QueryResponse
+	if err := json.Unmarshal(body, &qr); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &qr, nil
+}
+
+// PDFDownloadResult holds the result of downloading a PDF.
+type PDFDownloadResult struct {
+	Title    string
+	Year     string
+	FilePath string
+	FileSize int64
+}
+
+// DownloadPDF downloads an announcement PDF from the CNINFO CDN.
+func DownloadPDF(ctx context.Context, adjunctURL, destPath string) error {
+	fullURL, err := url.JoinPath(pdfBaseURL, adjunctURL)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to JoinPath", "error", err)
+		return err
+	}
+	resp, err := utils.MakeRequest(ctx, http.MethodGet, fullURL, nil, nil, 10*time.Minute)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to download PDF", "fullURL", fullURL, "error", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download PDF returned status %d", resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	written, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("downloaded PDF", "path", destPath, "size", written)
+	return nil
+}

--- a/provider/cninfo/cninfo_test.go
+++ b/provider/cninfo/cninfo_test.go
@@ -1,0 +1,70 @@
+package cninfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColumnForCode(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		// SSE main board
+		{"600036", "sse"},
+		{"600519", "sse"},
+		{"601398", "sse"},
+		{"603259", "sse"},
+		// SSE STAR
+		{"688001", "sse"},
+		{"688981", "sse"},
+		// BSE (Beijing)
+		{"830000", "bj"},
+		{"870000", "bj"},
+		{"430000", "bj"},
+		{"400000", "bj"},
+		// SZSE main board
+		{"000001", "szse"},
+		{"001979", "szse"},
+		// SZSE ChiNext
+		{"300750", "szse"},
+		{"301000", "szse"},
+		// short / default
+		{"6", "szse"},
+		{"", "szse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			require.Equal(t, tt.want, columnForCode(tt.code))
+		})
+	}
+}
+
+func TestPlateForCode(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		// SSE → sh
+		{"600036", "sh"},
+		{"688001", "sh"},
+		// BSE → bj
+		{"830000", "bj"},
+		{"430000", "bj"},
+		// SZSE (default) → sz
+		{"000001", "sz"},
+		{"300750", "sz"},
+		{"002001", "sz"},
+		// short / default → sz;sh
+		{"6", "sz;sh"},
+		{"", "sz;sh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			require.Equal(t, tt.want, plateForCode(tt.code))
+		})
+	}
+}

--- a/provider/eastmoney/balancesheet_test.go
+++ b/provider/eastmoney/balancesheet_test.go
@@ -36,7 +36,7 @@ func TestStripJSONP(t *testing.T) {
 		{
 			name:  "whitespace only",
 			input: `  `,
-			want: `  `,
+			want:  `  `,
 		},
 		{
 			name:    "no closing paren",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -82,6 +83,20 @@ func WriteJson(data interface{}, filePath string) error {
 
 	_, err = f.Write(v)
 	return err
+}
+
+// SecDir returns the path to the ~/.sec directory, creating it and any
+// specified subdirectories if they don't exist.
+func SecDir(sub ...string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(append([]string{home, ".sec"}, sub...)...)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
 }
 
 // JSONify json 序列化

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -52,3 +52,15 @@ func TestWriteJson(t *testing.T) {
 	err = WriteJson(data, filePath)
 	require.Nil(t, err)
 }
+
+func TestSecDir(t *testing.T) {
+	dir, err := SecDir("cache")
+	require.Nil(t, err)
+	require.NotEmpty(t, dir)
+	require.Contains(t, dir, ".sec")
+	require.Contains(t, dir, "cache")
+
+	info, err := os.Stat(dir)
+	require.Nil(t, err)
+	require.True(t, info.IsDir())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sec balance-sheet-download` (alias `sec bsd`) to find and download annual report PDFs from CNINFO, with year or year-range filtering and custom output directory.
* **Documentation**
  * Expanded balance-sheet docs and changelog with CNINFO PDF workflow, usage examples, and architecture notes.
* **Utilities**
  * Added a user cache/config directory helper for storing cached data.
* **Tests**
  * New unit tests for balance-sheet command, CNINFO mappings, and utility behavior.
* **Chores**
  * Updated ignore list to exclude additional workspace/files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alwqx/sec/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->