### PR TITLE
cmd: upgrade human byte binary size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## sec change log
 
+### v0.3.6
+
+1. `sec upgrade` 升级时下载文件大小使用 HumanByte 可读改造
+
 ### v0.3.5
 
 1. `sec strategy` 基础策略

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alwqx/sec/types"
 	"github.com/alwqx/sec/utils"
 	"github.com/alwqx/sec/version"
 	"github.com/spf13/cobra"
@@ -80,7 +81,7 @@ func UpgradeHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Downloading %s (%d bytes)...\n", asset.Name, asset.Size)
+	fmt.Printf("Downloading %s (%s)...\n", asset.Name, types.HumanByte(float64(asset.Size)))
 
 	// 获取当前二进制路径
 	execPath, err := os.Executable()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File sizes displayed during upgrade operations now appear in human-readable format (such as MB, GB) instead of raw bytes, improving clarity when monitoring downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->