### PR TITLE
cmd: init ipo

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,21 @@
       "Bash(python3 *)",
       "Bash(go list *)",
       "Bash(staticcheck *)",
-      "Bash(go clean *)"
+      "Bash(go clean *)",
+      "WebFetch(domain:akshare.akfamily.xyz)",
+      "WebFetch(domain:www1.hkexnews.hk)",
+      "WebFetch(domain:www.hkex.com.hk)",
+      "WebFetch(domain:webapi.cninfo.com.cn)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:data.eastmoney.com)",
+      "WebFetch(domain:www.hkexnews.hk)",
+      "WebFetch(domain:tushare.pro)",
+      "WebFetch(domain:quote.eastmoney.com)",
+      "WebFetch(domain:www.bse.cn)",
+      "WebFetch(domain:push2.eastmoney.com)",
+      "Bash(/tmp/sec ipo *)",
+      "Bash(gofmt -w provider/eastmoney/ipo_test.go)",
+      "Bash(gofmt -l provider/eastmoney/)"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## sec change log
 
+### v0.3.9
+
+1. 新增 `sec ipo` 命令族：`ipo list`（新股上市列表）、`ipo calendar`（新股排期视图）、`ipo prospectus`（IPO 招股说明书 PDF 链接）
+2. 数据来源：东方财富 push2（新股列表）+ 巨潮资讯 cninfo（IPO 公告 / 招股书）
+3. `cninfo.QueryIPOs`、`cninfo.QueryIPOByDateRange` 新增：对 IPO 公告自动填充日期和 PDF 直链
+4. 东方财富 push2 对 Go 的 keep-alive 连接返回 EOF：新增 `newHTTPClient` 禁用 keep-alive 和 IPv6，`fetchIPOListBatch` 内置 5 次指数退避重试
+
 ### v0.3.8
 
 1. 初始化 `sec insider` 命令

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alwqx/sec/cmd/balancesheet"
 	"github.com/alwqx/sec/cmd/bond"
 	"github.com/alwqx/sec/cmd/insider"
+	"github.com/alwqx/sec/cmd/ipo"
 	"github.com/alwqx/sec/cmd/kline"
 	"github.com/alwqx/sec/cmd/metal"
 	"github.com/alwqx/sec/cmd/quote"
@@ -81,6 +82,7 @@ func NewCLI() *cobra.Command {
 		watch.NewWatchCLI(),
 		announcements.NewAnnouncementsCLI(),
 		insider.NewInsiderCLI(),
+		ipo.NewIPOCLI(),
 	)
 
 	return rootCmd

--- a/cmd/ipo/ipo.go
+++ b/cmd/ipo/ipo.go
@@ -1,0 +1,448 @@
+// Package ipo provides the `sec ipo ...` command family:
+//
+//	sec ipo list        — recent IPO listings (name / code / listing date / price / PE / first-day change)
+//	sec ipo calendar    — upcoming IPO calendar (purchase / publish / listing dates)
+//	sec ipo prospectus  — IPO prospectus (招股说明书) URLs from CNINFO for a stock code
+package ipo
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/alwqx/sec/provider/cninfo"
+	"github.com/alwqx/sec/provider/eastmoney"
+	"github.com/alwqx/sec/provider/sina"
+	"github.com/alwqx/sec/utils"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// constants
+const (
+	defaultListSize     = 30
+	defaultPageSize     = 30
+	defaultMaxListTotal = 30
+	maxColumnWidth      = 24
+)
+
+// NewIPOCLI is the entrypoint; registered in cmd/cmd.go.
+func NewIPOCLI() *cobra.Command {
+	root := &cobra.Command{
+		Use:               "ipo",
+		Short:             "China mainland A-share IPO listings & prospectus (沪深京 IPO)",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	root.AddCommand(
+		newListCmd(),
+		newCalendarCmd(),
+		newProspectusCmd(),
+	)
+
+	return root
+}
+
+/* ----------------------------- ipo list ----------------------------- */
+
+func newListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recent or historical IPO listings (新股上市列表)",
+		Long: "List recent or historical A-share IPO listings from East Money PUSH2, " +
+			"listing the most-recent listings first. Filter by listing date with --since / --until.",
+		Aliases: []string{"ls"},
+		Example: `  sec ipo list                     # most recent 30 listings
+  sec ipo list --size 50            # most recent 50
+  sec ipo list --since 2024-01-01   # from specific date
+  sec ipo list --until 2024-12-31   # up to specific date`,
+		RunE: runList,
+	}
+	cmd.Flags().BoolP("debug", "D", false, "Enable debug mode")
+	cmd.Flags().IntP("size", "n", defaultListSize, "Number of listings to display (max 5000)")
+	cmd.Flags().String("since", "", "Only show listings on or after this date (YYYY-MM-DD)")
+	cmd.Flags().String("until", "", "Only show listings on or before this date (YYYY-MM-DD)")
+	return cmd
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	size, err := cmd.Flags().GetInt("size")
+	if err != nil {
+		return fmt.Errorf("size flag: %w", err)
+	}
+	if size <= 0 {
+		size = defaultMaxListTotal
+	}
+	if size > 5000 {
+		size = 5000
+	}
+	since, _ := cmd.Flags().GetString("since")
+	until, _ := cmd.Flags().GetString("until")
+
+	ctx := cmd.Context()
+
+	// 拉取足够多的数据以满足日期过滤
+	req := &eastmoney.IPOListReq{
+		PageNum:  1,
+		PageSize: size,
+		MaxTotal: size,
+	}
+	items, _, err := eastmoney.ListIPO(ctx, req)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to ListIPO", "since", since, "until", until, "error", err)
+		return fmt.Errorf("获取新股列表失败: %w", err)
+	}
+
+	filtered := make([]*eastmoney.IListing, 0, len(items))
+	for _, it := range items {
+		// 日期区间过滤
+		if since != "" && it.ListingDate != "-" && it.ListingDate < strings.ReplaceAll(since, "-", "") {
+			continue
+		}
+		if until != "" && it.ListingDate != "-" && it.ListingDate > strings.ReplaceAll(until, "-", "") {
+			continue
+		}
+		filtered = append(filtered, it)
+	}
+	if len(filtered) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "未找到 IPO 记录（尝试放宽年份或 --size）")
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	printIPOList(out, filtered)
+	return nil
+}
+
+func printIPOList(out io.Writer, items []*eastmoney.IListing) {
+	table := tablewriter.NewWriter(out)
+	// 仅保留确定性高的字段（东方财富各股发行价/PE 字段顺序会随 fs 改变，
+	// 列表 UI 仅承诺代码、名称、上市日）
+	headers := []string{"代码", "名称", "上市日"}
+	table.SetHeader(headers)
+	headerStyles := make([]tablewriter.Colors, len(headers))
+	for i := range headers {
+		headerStyles[i] = tablewriter.Colors{tablewriter.Bold}
+	}
+	table.SetHeaderColor(headerStyles...)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding("\t")
+
+	for _, it := range items {
+		listingDate := "-"
+		if it.ListingDate != "-" && it.ListingDate != "" {
+			listingDate = dateSafe(it.ListingDate)
+		}
+
+		name := it.Name
+		if len([]rune(name)) > maxColumnValueWidth()/2 {
+			name = string([]rune(name)[:maxColumnValueWidth()/2]) + ".."
+		}
+
+		row := []string{it.Code, name, listingDate}
+		table.Append(row)
+	}
+	table.Render()
+	fmt.Fprintf(out, "\n共 %d 条; 使用 --since / --until 按上市日过滤。\n", len(items))
+}
+
+// maxColumnValueWidth returns the max display width parameter for name column
+func maxColumnValueWidth() int {
+	return maxColumnWidth
+}
+
+/* --------------------------- ipo calendar --------------------------- */
+
+func newCalendarCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "calendar",
+		Short: "Show upcoming IPO calendar (新股排期)",
+		Long: "List the upcoming IPO schedule including purchase dates, " +
+			"publish dates, and estimated listing dates. Data is from East Money.",
+		Aliases: []string{"cal"},
+		Example: `  sec ipo calendar                       # next month
+  sec ipo calendar --since 2026-06-01
+  sec ipo calendar --until 2026-08-31
+  sec ipo calendar --since 2026-06-01 --until 2026-06-30`,
+		RunE: runCalendar,
+	}
+	cmd.Flags().BoolP("debug", "D", false, "Enable debug mode")
+	cmd.Flags().String("since", "", "Start date (YYYY-MM-DD), default: today")
+	cmd.Flags().String("until", "", "End date (YYYY-MM-DD), default: start + 30 days")
+	return cmd
+}
+
+func runCalendar(cmd *cobra.Command, args []string) error {
+	since, _ := cmd.Flags().GetString("since")
+	until, _ := cmd.Flags().GetString("until")
+
+	ctx := cmd.Context()
+
+	// 东方财富 push2ex 新股日历接口已于 2026-07 前后被下线（无论是 push2 / push2ex 均 404）。
+	// 折中：利用 CNINFO 查询 IPO/发行公告日期（首次公开发行及上市公告），
+	// 按给定日期范围做过滤，输出"公告日期"作为最接近"排期"的视图。
+	announcements, err := cninfo.QueryIPOByDateRange(ctx, since, until, 50)
+	if err != nil {
+		return fmt.Errorf("获取新股日历失败: %w", err)
+	}
+
+	if len(announcements) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "未找到 IPO 相关公告；请确认 --since/--until 范围正确")
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\nIPO 公告日期视图（来源: 巨潮资讯 cninfo.com.cn; 接口: 首次公开发行及上市）\n\n")
+	printIPOCalendar(out, announcements)
+	return nil
+}
+
+// dateSafe 若 s 是 YYYYMMDD 格式则算成 YYYY-MM-DD；否则原样返回
+func dateSafe(s string) string {
+	if len(s) == 8 {
+		return s[:4] + "-" + s[4:6] + "-" + s[6:]
+	}
+	return s
+}
+
+func printIPOCalendar(out io.Writer, announcements []*cninfo.Announcement) {
+	table := tablewriter.NewWriter(out)
+	headers := []string{"公告日期", "代码", "名称", "公告标题", "大小"}
+	table.SetHeader(headers)
+	hs := make([]tablewriter.Colors, len(headers))
+	for i := range headers {
+		hs[i] = tablewriter.Colors{tablewriter.Bold}
+	}
+	table.SetHeaderColor(hs...)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding("\t")
+
+	for _, a := range announcements {
+		title := a.Title
+		if len([]rune(title)) > 60 {
+			title = string([]rune(title)[:57]) + "..."
+		}
+		sizeStr := "-"
+		if a.AdjunctSize > 0 {
+			sizeStr = utils.HumanByte(float64(a.AdjunctSize))
+		}
+		row := []string{dateSafe(a.Date), a.SecCode, a.SecName, title, sizeStr}
+		styles := make([]tablewriter.Colors, len(headers))
+		if strings.HasPrefix(a.Title, "招股说明") {
+			styles[3] = tablewriter.Colors{tablewriter.Bold}
+		}
+		table.Rich(row, styles)
+	}
+	table.Render()
+	fmt.Fprintf(out, "\n共 %d 条; 这是按公告日期排序的 IPO / 发行相关公告列表，可近似看作\"新股排期\"视图。\n", len(announcements))
+}
+
+/* ------------------------- ipo prospectus ------------------------- */
+
+func newProspectusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prospectus",
+		Short: "List IPO prospectus (招股说明书) URLs for a stock",
+		Long: "Fetch IPO-related announcements (招股意向书/招股说明书/发行公告) from CNINFO " +
+			"for the given stock code, and print the download link for each PDF.",
+		Aliases: []string{"psp"},
+		Example: `  sec ipo prospectus 300750         # prospectus for 宁德时代
+  sec ipo prospectus 600036 --size 10   # first 10 prospectus PDFs
+  sec ipo prospectus 300750 --since 2018-01-01 --until 2018-12-31`,
+		Args: cobra.ExactArgs(1),
+		RunE: runProspectus,
+	}
+	cmd.Flags().BoolP("debug", "D", false, "Enable debug mode")
+	cmd.Flags().IntP("size", "n", 20, "Maximum number of prospectus entries to list")
+	cmd.Flags().String("since", "", "Only show prospectuses on or after this date (YYYY-MM-DD)")
+	cmd.Flags().String("until", "", "Only show prospectuses on or before this date (YYYY-MM-DD)")
+	return cmd
+}
+
+func runProspectus(cmd *cobra.Command, args []string) error {
+	code := args[0]
+	size, _ := cmd.Flags().GetInt("size")
+	if size <= 0 {
+		size = 20
+	}
+	if size > 5000 {
+		size = 5000
+	}
+	since, _ := cmd.Flags().GetString("since")
+	until, _ := cmd.Flags().GetString("until")
+
+	ctx := cmd.Context()
+
+	// 1. 用户输入可能是简写（名称或代码），先用 sina 搜索做代码 + 市场匹配。
+	// sina 返回结果可能含港股/A 股同名项，cninfo 仅收录 A 股，因此优先选 A 股。
+	var stockCode, orgID, secName string
+	secs := sina.Search(ctx, code)
+	sec := firstAShare(secs)
+	if sec != nil {
+		stockCode = sec.Code
+		secName = sec.Name
+		resolvedOrgID, resolvedName, err := cninfo.LookupOrgID(ctx, stockCode)
+		if err != nil {
+			return fmt.Errorf("查找 %s 的公司身份失败: %w", stockCode, err)
+		}
+		orgID = resolvedOrgID
+		if resolvedName != "" {
+			secName = resolvedName
+		}
+	} else {
+		// sina 没搜到 A 股，尝试把用户输入当作 A 股代码
+		stockCode = sanitizeCode(code)
+		if !isACode(stockCode) {
+			return fmt.Errorf("未找到 %s 对应的 A 股代码，请确认代码无误", code)
+		}
+		resolvedOrgID, resolvedName, err := cninfo.LookupOrgID(ctx, stockCode)
+		if err != nil || resolvedOrgID == "" {
+			return fmt.Errorf("查找 %s 的公司身份失败: %w", stockCode, err)
+		}
+		orgID = resolvedOrgID
+		secName = resolvedName
+	}
+
+	stockParam := fmt.Sprintf("%s,%s", stockCode, orgID)
+	announcements, err := cninfo.QueryIPOs(ctx, stockParam, size)
+	if err != nil {
+		return fmt.Errorf("查询招股书失败: %w", err)
+	}
+
+	if len(announcements) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "未找到 %s (%s) 的 IPO 公告（cninfo 可能未收录或代码有误）\n", secName, stockCode)
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\n%s (%s) IPO 相关公告 (来源: 巨潮资讯 cninfo.com.cn)\n\n", secName, stockCode)
+
+	filtered := filterByDate(announcements, since, until)
+
+	printProspectus(out, filtered)
+	fmt.Fprintln(out)
+	return nil
+}
+
+// firstAShare 从 sina 搜索结果中优先选 A 股条目（跳过港股/美股同名项）
+func firstAShare(secs []*sina.BasicSecurity) *sina.BasicSecurity {
+	for _, s := range secs {
+		if s == nil {
+			continue
+		}
+		// 6 位数字代码 → A 股
+		if len(s.Code) == 6 {
+			return s
+		}
+		// SH/BJ 前缀
+		if len(s.ExCode) >= 2 {
+			prefix := strings.ToLower(s.ExCode[:2])
+			if prefix == "sh" || prefix == "sz" || prefix == "bj" {
+				return s
+			}
+		}
+	}
+	// fallback: 任意一条
+	if len(secs) > 0 {
+		return secs[0]
+	}
+	return nil
+}
+
+// sanitizeCode 把用户输入形如 "SZ300750" / "300750" 统一为纯 6 位代码
+func sanitizeCode(code string) string {
+	c := strings.ToUpper(strings.TrimSpace(code))
+	c = strings.TrimPrefix(c, "SH")
+	c = strings.TrimPrefix(c, "SZ")
+	c = strings.TrimPrefix(c, "BJ")
+	c = strings.TrimPrefix(c, "HK")
+	return strings.TrimSpace(c)
+}
+
+func isACode(code string) bool {
+	if len(code) != 6 {
+		return false
+	}
+	prefix := code[:2]
+	return prefix == "60" || prefix == "68" || prefix == "30" || prefix == "00" || prefix == "83" || prefix == "87" || prefix == "43" || prefix == "40"
+}
+
+func filterByDate(announcements []*cninfo.Announcement, since, until string) []*cninfo.Announcement {
+	if since == "" && until == "" {
+		return announcements
+	}
+	sinceInt := strings.ReplaceAll(since, "-", "")
+	untilInt := strings.ReplaceAll(until, "-", "")
+	out := make([]*cninfo.Announcement, 0, len(announcements))
+	for _, a := range announcements {
+		if since != "" && a.Date < sinceInt {
+			continue
+		}
+		if until != "" && a.Date > untilInt {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+func printProspectus(out io.Writer, announcements []*cninfo.Announcement) {
+	if len(announcements) == 0 {
+		fmt.Fprintln(out, "（经日期过滤后无匹配记录）")
+		return
+	}
+
+	table := tablewriter.NewWriter(out)
+	headers := []string{"公告日期", "公告标题", "大小", "PDF 链接"}
+	table.SetHeader(headers)
+	headerStyles := make([]tablewriter.Colors, len(headers))
+	for i := range headers {
+		headerStyles[i] = tablewriter.Colors{tablewriter.Bold}
+	}
+	table.SetHeaderColor(headerStyles...)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding("\t")
+
+	seenProspectus := false
+	for _, a := range announcements {
+		sizeStr := "-"
+		if a.AdjunctSize > 0 {
+			sizeStr = utils.HumanByte(float64(a.AdjunctSize))
+		}
+		title := a.Title
+		if len([]rune(title)) > 60 {
+			title = string([]rune(title)[:57]) + "..."
+		}
+		isIPO := strings.Contains(title, "招股")
+		if isIPO {
+			seenProspectus = true
+		}
+
+		styles := make([]tablewriter.Colors, len(headers))
+		if isIPO {
+			styles[1] = tablewriter.Colors{tablewriter.Bold}
+		}
+		row := []string{a.Date, title, sizeStr, a.PDFURL}
+		table.Rich(row, styles)
+	}
+	table.Render()
+
+	if !seenProspectus {
+		slog.Warn("no exact '招股' announcement in results; all IPO-related announcements are shown")
+	}
+}

--- a/docs/research-ipo.md
+++ b/docs/research-ipo.md
@@ -1,0 +1,228 @@
+# IPO / 上市信息功能调研
+
+> 目标：在中国大陆（沪深京）和香港证券市场提供「上市公司列表、上市时间、招股说明书」信息的查询能力。
+> 状态：调研阶段（2026-07-02）
+
+---
+
+## 一、官方数据源
+
+### 1.1 中国大陆（A 股）
+
+| 交易所 | 披露入口 | 提供内容 |
+|--------|----------|----------|
+| 上海证券交易所（SSE） | `https://www.sse.com.cn/ipo/` | 审核进展、预披露、招股书（科创板：`https://kcb.sse.com.cn/xqsj/`） |
+| 深圳证券交易所（SZSE） | `https://www.szse.cn/ipo/` | 审核进展、招股书申报稿（最终链接走巨潮） |
+| 北京证券交易所（BSE） | `https://www.bse.cn/disclosure/info.html` | IPO 审核状态、招股书、上市公司数据 |
+| **巨潮资讯（cninfo）** | `https://www.cninfo.com.cn` | ⭐ 证监会指定信息披露平台，沪深京三地 IPO 公告、定稿招股书 PDF |
+
+### 1.2 香港（HKEX）
+
+| 入口 | 提供内容 |
+|------|----------|
+| `https://www.hkexnews.hk` | PDF 下载：招股书、聆讯后资料集、上市通告 |
+| `https://www3.hkexnews.hk/hyperlink/hyperlist.HTM` | 每日上市公司清单（CSV/Excel，含代码、名称、板块、上市日期） |
+| `https://www.hkex.com.hk/Listing/Listing-Information/Main-Board-IPO-and-New-Listing?sc_lang=en` | 待上市/已审批 IPO 日历 |
+| `https://www1.hkexnews.hk/search/titlesearch.xhtml` | 招股书文档检索入口 |
+
+---
+
+## 二、第三方数据 API / SDK
+
+### 2.1 推荐入口
+
+| 数据源 | 覆盖 | 招股书链接 | 获取方式 | 是否收费 |
+|--------|------|-----------|----------|----------|
+| **巨潮资讯 API**（被 AKShare 等封装） | SSE/SZSE/BSE | ✅（详情页 → PDF） | 非官方 POST JSON API | 免费 |
+| **AKShare** `stock_zh_a_disclosure_report_cninfo()` | SSE/SZSE/BSE | ✅ | Python 封装巨潮 API | 免费 |
+| **东方财富 PUSH2** `fid=f26` | SSE/SZSE/BSE | ❌（仅跳转链接） | 公开 REST JSON | 免费 |
+| **AKShare** `stock_new_ipo_em()` | SSE/SZSE/BSE | ❌ | 东方财富新股接口 | 免费 |
+| **Tushare Pro** `new_share()` | SSE/SZSE（BSE 部分） | ❌ | Token + 积分 | 部分付费 |
+| **HKEX hyperlist.csv** | HK | ❌ | 直链下载 | 免费 |
+| **HKEX News Search** | HK | ✅（PDF） | HTML 抓取 | 免费 |
+
+> 除巨潮资讯外，免费渠道**极少直接给出 PDF 下载直链**——多数给出公告详情页 URL，再二次解析拿到 PDF。
+
+### 2.2 巨潮资讯 API（cninfo）详细剖析
+
+这是综合性价比最高的方案，本项目 `provider/cninfo/` 已调用过其公告接口。
+
+```
+POST http://www.cninfo.com.cn/new/hisAnnouncement/query
+Content-Type: application/x-www-form-urlencoded
+
+pageNum=1&pageSize=30
+column=szse                # szse | sse | SSE | (空可查)
+stock=&searchkey=
+category=category_sf_szsh  # 首次公开发行及上市
+seDate=2024-01-01~2024-12-31
+sortName=&sortType=
+isHLtitle=true
+```
+
+```json
+{
+  "totalAnnouncement": 1234,
+  "announcements": [
+    {
+      "announcementId": "12345678",
+      "secCode": "300001",
+      "secName": "特锐德",
+      "announcementTitle": "首次公开发行股票并在创业板上市招股说明书",
+      "storageTime": "2024-06-01 00:00:00",
+      "adjunctUrl": "/new/disclosure/detail?stockCode=300001&announcementId=12345678&orgId=990000xxx"
+    }
+  ]
+}
+```
+
+- 详情页访问 `cninfo.com.cn/new/disclosure/detail?...` 即可获得 PDF 下载入口。
+- `category` 字段对照表（cninfo 官方分类编码）：
+
+| 分类编码 | 含义 |
+|----------|------|
+| `category_ndbg_szsh` | 年度报告 |
+| `category_sf_szsh` | **首次公开发行及上市（IPO）** |
+| `category_scgkfx_szsh` | 招股发行上市（再融资类） |
+- 频率限制：非正式 API，建议 3–5 秒/请求，并走本地缓存。
+
+### 2.3 东方财富 PUSH2（新股列表）
+
+```
+# 新股列表
+GET https://push2.eastmoney.com/api/qt/clist/get
+  ?fid=f26                 # 按上市时间排序
+  &fs=m:0+t:80+t:81+s:2048 # 沪深北交所 + 科创板 + 创业板
+  &po=1&pz=50&pn=1
+
+# 新股日历（近期 IPO 排期）
+GET https://push2ex.eastmoney.com/api/qt/newcalendar/get
+  ?source=newstock&client=app&start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+
+# 单股查询（代码 + 名称 + 上市时间）
+GET https://push2.eastmoney.com/api/qt/stock/get
+  ?secid=0.300001&fields=f57,f58,f116,f117,f169,f170,f171,f26
+```
+
+主要字段：`f57`=代码、`f58`=名称、`f26`=上市日期、`f43`=发行价、`f44`=市盈率。
+东方财富优势是**价格 / PE / 中签率**，缺点是无 PDF 直链。
+
+### 2.4 HKEX
+
+```text
+# 全量上市公司清单（每日更新）
+GET https://www3.hkexnews.hk/hyperlink/hyperlist.HTM   → 实际重定向到 .csv 下载
+
+# 招股书搜索（表单提交）
+POST https://www1.hkexnews.hk/search/searchindex.xhtml
+  lang=ZH
+  category=0
+  from=20240101&to=20241231
+  stockId=00700
+  title=
+  t1code=40000            # 主板新上市 / 招股书
+  &searchType=1
+```
+
+> HKEX 在 2024–2025 年已将 `searchnew.aspx` 等旧端点下线，迁移到 `searchindex.xhtml`。抓取脚本较脆弱，建议每月重新校验一次选择器。
+
+---
+
+## 三、A 股实现路线（推荐）
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│  IPO 元数据 │ 上市公司列表 │ 上市日历 │ 即将上市      │
+└──────┬──────────────────────────────────────────────────┘
+       │
+       ▼
+┌────────────────────┐     ┌────────────────────────────────┐
+│ 东方财富 PUSH2     │────▶│  代码、名称、上市日、发行价、PE │
+│（push2.eastmoney）  │     │  pz<=300 分页即可              │
+└────────────────────┘     └────────────────────────────────┘
+       │
+       ▼（需要 PDF 时）
+┌─────────────────────────────────────────┐
+│ 巨潮资讯 cninfo                          │
+│ POST /new/hisAnnouncement/query         │
+│ category=category_sf_szsh               │
+│ → 公告列表 → 详情页 → PDF 直链          │
+└─────────────────────────────────────────┘
+```
+
+| 步骤 | 数据源 | Go 方法 | 返回 |
+|------|--------|---------|------|
+| `List()` — 已上市公司 | 东方财富 push2 `fid=f26` | `provider/eastmoney/ipo.go` | 代码、名称、上市日期、发行价、PE、首日涨跌幅 |
+| `Calendar()` — 新股日历 | 东方财富 push2ex newcalendar | `provider/eastmoney/calendar.go` | 申购日、缴款日、预计上市日 |
+| `Prospectus()` — 招股书 | 巨潮 cninfo `category_sf_szsh` | `provider/cninfo/prospectus.go` | 公告标题、日期、PDF URL |
+
+---
+
+## 四、港股实现路线
+
+| 步骤 | 数据源 | Go 方法 | 返回 |
+|------|--------|---------|------|
+| `List()` — 全量上市公司 | `hkexnews.hk` hyperlist CSV | `provider/hkex/list.go` | 代码、名称、板块、ISIN、上市日期 |
+| `Prospectus()` — 招股书 | HKEX 标题搜索 `t1code=40000` | `provider/hkex/prospectus.go` | 公告标题、日期、PDF URL |
+
+> HKEX 较脆弱：CSV 直链稳定可用作「已上市公司」的权威源；招股书抓取需配合 cookie 会话 + HTML 解析，适合低频调用（每日/每周缓存）。
+
+---
+
+## 五、Go 复用性 / 已有基础设施
+
+本项目（sec CLI）已具备的基本能力可直接复用：
+
+| 组件 | 位置 | 用途 |
+|------|------|------|
+| `utils.MakeRequest` | `utils/http.go` | 通用 HTTP GET/POST、重试、UA、超时 |
+| `GBK/GB18030 → UTF-8` | `utils/encoding.go` | 巨潮/东方财富部分页面为 GBK |
+| `provider/cninfo/` | 已存在 | 调用过 `query` 公告接口，可直接增 IPO/招股书函数 |
+| `provider/eastmoney/` | 已存在 | kline / quote-history 的 push2 模式可直接拷贝 |
+| `tablewriter` + 着色 | 现有命令统一用法 | IPO 列表、日历渲染 |
+
+推荐落地路径：
+
+1. `provider/eastmoney/ipo.go` — 上市公司列表 + 新股日历（纯 REST JSON，最稳）
+2. `provider/eastmoney/calendar.go`（或合入 ipo.go）— 新股日历
+3. `provider/cninfo/prospectus.go` — 巨潮 IPO 公告 + 详情页 → PDF 链接
+4. `provider/hkex/` — `list.go`（超链 CSV）+ `prospectus.go`（标题搜索抓取）
+5. `cmd/ipo/ipo.go` — cobra 子命令，`List/Prospectus/Calendar` 三个子命令
+6. `cmd/cmd.go` — 注册 `ipoCmd`
+
+---
+
+## 六、风险与注意事项
+
+| 风险 | 缓解 |
+|------|------|
+| 巨潮 cninfo 为非官方接口，字段可能调整 | 封装在 `provider/cninfo/`，添加 ETag/缓存，失败回退 |
+| 东方财富 PUSH2 字段 ID 是密文（f26 等） | 写死常量 + 字段映射；单测覆盖 |
+| HKEX 频繁重构前端（最近一次 2024-02） | prospectus 仅每日抓取一次；列为主观功能而非 SLA |
+| 巨潮频率触警（约 3 秒/次） | 本地 TTL 缓存（24h），列表类命令默认读缓存 |
+| GBK 编码（老站点） | 复用 `utils.SimplifiedChinese` |
+| BSE（北交所）上市公司数较少（~250） | 东方财富已含，cninfo `column=sse` 同样命中北交所 |
+
+---
+
+## 七、最终建议
+
+1. **MVP（1 周内可期）**：东方财富 PUSH2 + 巨潮 cninfo 提供「沪深北交所 IPO 列表 + 配套招股书」，只读缓存 + 命令行表格渲染。
+2. **扩展（2 周）**：HKEX hyperlist CSV 做港股上市公司清单；HKEX 标题搜索做招股书（半脆弱，仅低频调用）。
+3. **可选升级**：付费 Tushare Pro（¥2,000/年）提供稳定 SLA，覆盖历史 IPO 全量档案。
+4. **暂不做**：付费数据终端（Wind/Bloomberg）与纯网页爬取（SSE/SZSE 各自披露页）。
+
+---
+
+## 八、参考链接
+
+- [AKShare IPO 数据文档](https://akshare.akfamily.xyz/data/ipo/ipo.html)
+- [巨潮资讯 (cninfo.com.cn)](https://www.cninfo.com.cn)
+- [深证信 API 文档](http://webapi.cninfo.com.cn/#/apiDoc)
+- [东方财富新股数据](https://data.eastmoney.com/xg/xg/default.html)
+- [SSE IPO 披露](https://ipo.sse.com.cn/renewal/)
+- [SZSE IPO 披露](http://www.szse.cn/ipo/)
+- [HKEX News Disclosure](https://www.hkexnews.hk)
+- [HKEX 上市公司超链清单](https://www3.hkexnews.hk/hyperlink/hyperlist.HTM)
+- [HKEX 上市日历](https://www.hkex.com.hk/Listing/Listing-Information/Main-Board-IPO-and-New-Listing)
+- [Tushare Pro](https://tushare.pro)

--- a/provider/cninfo/cninfo.go
+++ b/provider/cninfo/cninfo.go
@@ -23,13 +23,16 @@ import (
 const (
 	stockListURL = "https://www.cninfo.com.cn/new/data/szse_stock.json"
 	queryURL     = "https://www.cninfo.com.cn/new/hisAnnouncement/query"
+	detailURL    = "https://www.cninfo.com.cn/new/disclosure/detail"
 	pdfBaseURL   = "http://static.cninfo.com.cn"
 
 	// Announcement category codes
-	CategoryAnnual   = "category_ndbg_szsh"  // 年报
-	CategoryHalfYear = "category_bndbg_szsh" // 半年报
-	CategoryQ1       = "category_yjdbg_szsh" // 一季报
-	CategoryQ3       = "category_sjdbg_szsh" // 三季报
+	CategoryAnnual   = "category_ndbg_szsh"   // 年报
+	CategoryHalfYear = "category_bndbg_szsh"  // 半年报
+	CategoryQ1       = "category_yjdbg_szsh"  // 一季报
+	CategoryQ3       = "category_sjdbg_szsh"  // 三季报
+	CategoryIPO      = "category_sf_szsh"     // 首次公开发行及上市（招股书）
+	CategoryProspect = "category_scgkfx_szsh" // 招股说明书公开发行
 )
 
 // StockInfo holds a stock entry from the CNINFO stock list.
@@ -54,6 +57,9 @@ type Announcement struct {
 	TypeName         string `json:"announcementTypeName"`
 	ExistFlag        int    `json:"existFlag"`
 	InvalidationFlag int    `json:"invalidationFlag"`
+	// Derived fields, 非 JSON 字段，由本包内部计算填充
+	Date   string // YYYYMMDD，由 Time(毫秒) 字段派生
+	PDFURL string // 完整 PDF 下载直链，由 AdjunctURL 派生
 }
 
 // QueryRequest holds parameters for querying announcements.
@@ -76,6 +82,57 @@ type QueryResponse struct {
 }
 
 // columnForCode determines the exchange column parameter from a stock code.
+// QueryIPOByDateRange 按公告日期范围查询 IPO / 发行相关公告。
+// CNINFO 按 seDate 参数做过滤：seDate = "{start} ~ {end}"，其中日期格式为 YYYY-MM-DD。
+// 返回范围为 (start, end) 区间内所有 category_sf_szsh 公告（亦含少量 scgkfx）。
+func QueryIPOByDateRange(ctx context.Context, startDate, endDate string, max int) ([]*Announcement, error) {
+	const pageSize = 30 // cninfo pageSize 固定 30（见 QueryAnnouncements 内部约束）
+	items := make([]*Announcement, 0)
+	pageNum := 1
+
+	for {
+		req := &QueryRequest{
+			Category:  CategoryIPO,
+			PageNum:   pageNum,
+			PageSize:  pageSize,
+			StartDate: startDate,
+			EndDate:   endDate,
+		}
+
+		resp, err := QueryAnnouncements(ctx, req)
+		if err != nil {
+			return items, fmt.Errorf("QueryIPOByDateRange: %w", err)
+		}
+		if resp == nil || len(resp.Data) == 0 {
+			break
+		}
+
+		for _, a := range resp.Data {
+			if a == nil {
+				continue
+			}
+			if a.Time > 0 {
+				a.Date = time.Unix(a.Time/1000, 0).Format("20060102")
+			}
+			// if a.AdjunctURL != "" && !strings.HasPrefix(a.AdjunctURL, "http") {
+			// 	a.PDFURL = "http://static.cninfo.com.cn/" + strings.TrimLeft(a.AdjunctURL, "/")
+			// } else {
+			// 	a.PDFURL = a.AdjunctURL
+			// }
+			a.PDFURL = resolvePDFURL(a)
+			items = append(items, a)
+			if max > 0 && len(items) >= max {
+				return items, nil
+			}
+		}
+		if !resp.HasMore {
+			break
+		}
+		pageNum++
+	}
+	return items, nil
+}
+
 func columnForCode(code string) string {
 	if len(code) < 2 {
 		return "szse"
@@ -199,6 +256,52 @@ func LookupOrgID(ctx context.Context, code string) (string, string, error) {
 	return "", "", fmt.Errorf("stock code %s not found in CNINFO stock list", code)
 }
 
+// QueryIPOs 查询指定股票的 IPO 相关公告（招股书、发行公告等）。
+// 覆盖 category_sf_szsh（首次公开发行及上市），并在返回时解析 PDF 直链。
+func QueryIPOs(ctx context.Context, stockCode string, size int) ([]*Announcement, error) {
+	if size <= 0 || size > 5000 {
+		size = 30
+	}
+	req := &QueryRequest{
+		StockCode: stockCode,
+		Category:  CategoryIPO,
+		PageSize:  size,
+	}
+
+	resp, err := QueryAnnouncements(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// 对每个公告解析 PDF 直链 & 日期（由 Time(ms) 派生）
+	out := make([]*Announcement, 0)
+	for _, a := range resp.Data {
+		if a == nil {
+			continue
+		}
+		// 从毫秒时间戳派生日期（YYYYMMDD）
+		if a.Time > 0 {
+			a.Date = time.Unix(a.Time/1000, 0).Format("20060102")
+		}
+
+		// 解析 PDF 直链：优先用 AdjunctURL 直接拼接，
+		// 否则构造 detail 链接
+		// if a.AdjunctURL != "" && !strings.HasPrefix(a.AdjunctURL, "http") {
+		// 	a.PDFURL = "http://static.cninfo.com.cn/" + strings.TrimLeft(a.AdjunctURL, "/")
+		// } else {
+		// 	a.PDFURL = a.AdjunctURL
+		// }
+		a.PDFURL = resolvePDFURL(a)
+
+		if a.PDFURL == "" {
+			a.PDFURL = fmt.Sprintf("https://www.cninfo.com.cn/new/disclosure/detail?stockCode=%s&announcementId=%s&orgId=%s",
+				a.SecCode, a.ID, a.OrgID)
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
 // QueryAnnouncements queries CNINFO for announcements matching the request.
 func QueryAnnouncements(ctx context.Context, req *QueryRequest) (*QueryResponse, error) {
 	if req == nil {
@@ -279,6 +382,17 @@ func QueryAnnouncements(ctx context.Context, req *QueryRequest) (*QueryResponse,
 	}
 
 	return &qr, nil
+}
+
+// resolvePDFURL
+func resolvePDFURL(a *Announcement) string {
+	if a.AdjunctURL != "" && !strings.HasPrefix(a.AdjunctURL, "http") {
+		return pdfBaseURL + "/" + strings.TrimLeft(a.AdjunctURL, "/")
+	}
+	if a.AdjunctURL != "" {
+		return a.AdjunctURL
+	}
+	return fmt.Sprintf("%s?stockCode=%s&announcementId=%s&orgId=%s", detailURL, a.SecCode, a.ID, a.OrgID)
 }
 
 // PDFDownloadResult holds the result of downloading a PDF.

--- a/provider/cninfo/cninfo_test.go
+++ b/provider/cninfo/cninfo_test.go
@@ -68,3 +68,95 @@ func TestPlateForCode(t *testing.T) {
 		})
 	}
 }
+
+func TestResolvePDFURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *Announcement
+		want string
+	}{
+		{
+			name: "relative path (typical cninfo adjunct url)",
+			in: &Announcement{
+				SecCode:    "300750",
+				ID:         "1205010303",
+				OrgID:      "GD165627",
+				AdjunctURL: "finalpage/2018-05-29/1205010303.PDF",
+			},
+			want: "http://static.cninfo.com.cn/finalpage/2018-05-29/1205010303.PDF",
+		},
+		{
+			name: "relative path with leading slash",
+			in: &Announcement{
+				SecCode:    "600036",
+				ID:         "123",
+				OrgID:      "gssh0600036",
+				AdjunctURL: "/finalpage/2024-01-01/123.PDF",
+			},
+			want: "http://static.cninfo.com.cn/finalpage/2024-01-01/123.PDF",
+		},
+		{
+			name: "absolute http url returned as-is",
+			in: &Announcement{
+				SecCode:    "000001",
+				ID:         "456",
+				OrgID:      "9900000001",
+				AdjunctURL: "http://other-cdn.example.com/path/doc.pdf",
+			},
+			want: "http://other-cdn.example.com/path/doc.pdf",
+		},
+		{
+			name: "absolute https url returned as-is",
+			in: &Announcement{
+				SecCode:    "000001",
+				ID:         "456",
+				OrgID:      "9900000001",
+				AdjunctURL: "https://static.cninfo.com.cn/finalpage/2024-01-01/456.PDF",
+			},
+			want: "https://static.cninfo.com.cn/finalpage/2024-01-01/456.PDF",
+		},
+		{
+			name: "empty adjunct url falls back to detail page",
+			in: &Announcement{
+				SecCode: "300750",
+				ID:      "1205010303",
+				OrgID:   "GD165627",
+			},
+			want: "https://www.cninfo.com.cn/new/disclosure/detail?stockCode=300750&announcementId=1205010303&orgId=GD165627",
+		},
+		{
+			name: "empty adjunct url with empty fields",
+			in:   &Announcement{},
+			want: "https://www.cninfo.com.cn/new/disclosure/detail?stockCode=&announcementId=&orgId=",
+		},
+		{
+			name: "single-slash relative path",
+			in: &Announcement{
+				SecCode:    "600036",
+				ID:         "789",
+				OrgID:      "gssh0600036",
+				AdjunctURL: "/abc.pdf",
+			},
+			want: "http://static.cninfo.com.cn/abc.pdf",
+		},
+		{
+			name: "adjunct url that starts with http but lower-case",
+			in: &Announcement{
+				SecCode:    "600036",
+				ID:         "789",
+				OrgID:      "gssh0600036",
+				AdjunctURL: "http:/malformed/doc.pdf",
+			},
+			// Starts with "http" but lacks the second slash; current impl treats any
+			// "http"-prefixed url as absolute (Prefix match). Document the behavior.
+			want: "http:/malformed/doc.pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePDFURL(tt.in)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/provider/eastmoney/calendar.go
+++ b/provider/eastmoney/calendar.go
@@ -1,0 +1,100 @@
+package eastmoney
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/alwqx/sec/utils"
+)
+
+// IPOCalendar provider: 东方财富新股日历（近期 IPO 排期，含申购、中签日等）。
+// 接口暴露给 AKShare / efinance 社区，非官方。
+
+const (
+	ipoCalendarURL = "http://push2ex.eastmoney.com/api/qt/newcalendar/get"
+)
+
+// IPOCalendarItem 新股日历一条记录
+type IPOCalendarItem struct {
+	StatusCode    string `json:"status_code"` // 0: 已打新, 1: 待申购, 2: 待上市
+	StatusLabel   string `json:"status_label"`
+	Code          string `json:"code"`
+	Name          string `json:"name"`
+	PurchaseCode  string `json:"purchase_code"`
+	PurchaseDate  string `json:"purchase_date"`  // 申购日期 YYYY-MM-DD
+	PublishDate   string `json:"publish_date"`   // 中签/配售结果公布
+	ListingDate   string `json:"listing_date"`   // 预计上市日 YYYY-MM-DD
+	PurchaseLimit string `json:"purchase_limit"` // 申购上限（万元）
+	PE            string `json:"pe"`             // 市盈率（发行价口径）
+	IssuePrice    string `json:"issue_price"`    // 发行价
+	TotalAmount   string `json:"total_amount"`   // 募资总额
+	TotalShares   string `json:"total_shares"`   // 发行股数
+	Date          string `json:"date"`           // 数据日期
+	Exchange      string `json:"exchange"`       // sh/sz/bj
+}
+
+// IPOListCalendarReq 新股日历查询请求
+type IPOListCalendarReq struct {
+	StartDate string // 查询开始日期 YYYY-MM-DD
+	EndDate   string // 查询结束日期 YYYY-MM-DD；0 值时默认 StartDate+1 月
+}
+
+// IPOCalendarResponse 东财新股日历返回结构
+type IPOCalendarResponse struct {
+	Data []*IPOCalendarItem `json:"data"`
+}
+
+// ListIPOCalendar 获取新股日历（近期 IPO 排期）
+func ListIPOCalendar(ctx context.Context, req *IPOListCalendarReq) ([]*IPOCalendarItem, error) {
+	if req == nil {
+		return nil, fmt.Errorf("req is nil")
+	}
+
+	startDate := req.StartDate
+	if startDate == "" {
+		startDate = time.Now().Format(utils.LayoutYYMMDD)
+	}
+	endDate := req.EndDate
+	if endDate == "" {
+		// 默认为 start 后一个月
+		t, err := time.Parse(utils.LayoutYYMMDD, startDate)
+		if err != nil {
+			return nil, fmt.Errorf("invalid start_date: %w", err)
+		}
+		endDate = t.AddDate(0, 1, 0).Format(utils.LayoutYYMMDD)
+	}
+
+	v := url.Values{}
+	v.Set("source", "newstock")
+	v.Set("client", "app")
+	v.Set("start_date", startDate)
+	v.Set("end_date", endDate)
+
+	reqURL := ipoCalendarURL + "?" + v.Encode()
+	// 东方财富 push2ex 要求浏览器 UA
+	headers := http.Header{}
+	headers.Set("User-Agent", browserUA)
+	headers.Set("Accept", "*/*")
+	client := newHTTPClient(defaultTimeout)
+	resp, err := doRequest(ctx, client, http.MethodGet, reqURL, headers, nil)
+	if err != nil {
+		return nil, fmt.Errorf("eastMoney IPO calendar request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("eastMoney IPO calendar read: %w", err)
+	}
+
+	var raw IPOCalendarResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("eastMoney IPO calendar parse: %w", err)
+	}
+	return raw.Data, nil
+}

--- a/provider/eastmoney/ipo.go
+++ b/provider/eastmoney/ipo.go
@@ -1,0 +1,338 @@
+package eastmoney
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultTimeout = 10 * time.Second
+
+// newHTTPClient 返回仅走 IPv4 的 HTTP Client（东方财富 push2 接口 IPv6 不可达，且 keep-alive 导致 EOF）。
+func newHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: timeout,
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "tcp4", addr)
+			},
+			// 东方财富 push2 对 Go 的 keep-alive 连接返回 EOF；强制禁用
+			DisableKeepAlives:   true,
+			MaxIdleConns:        0,
+			MaxIdleConnsPerHost: 0,
+		},
+		Timeout: timeout,
+	}
+}
+
+// doRequest 在指定 http.Client 上发送请求
+func doRequest(ctx context.Context, client *http.Client, method, reqURL string, headers http.Header, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	if headers != nil {
+		req.Header = headers
+	} else {
+		req.Header.Set("User-Agent", utilsUserAgent)
+	}
+	return client.Do(req)
+}
+
+const utilsUserAgent = "sec/1.0 (+https://github.com/alwqx/sec)"
+
+// IPO provider: 基于东方财富 PUSH2 的新股列表（已上市/待上市）。
+//
+// 接口文档（非官方）: http://push2.eastmoney.com/api/qt/clist/get
+// 字段语义参考 AKShare stock_new_ipo_em / efinance get_ipo_info 源码。
+
+// IPO 列表 field constants（东方财富 push2 接口字段 ID）
+var (
+	// ipoURL 用 var 而非 const 以方便测试用 httptest server 覆盖
+	ipoURL = "http://push2.eastmoney.com/api/qt/clist/get"
+
+	// 请求字段
+	ipoFields = "f12,f14,f26,f33,f43,f44,f45,f57,f58,f162,f163,f167,f2,f3,f4"
+
+	// f12:  证券代码
+	// f14:  证券简称
+	// f26:  上市日期（20260702 / -）
+	// f33:  发行价（元）
+	// f43:  发行市盈率 PE（东财用 100 倍整数存储：/100 即实际值）
+	// f44:  行业 PE（100 倍整数）
+	// f45:  首日涨跌幅（%，100 倍整数）
+	// f57:  首日收盘价
+	// f58:  首日开盘价
+	// f162: 网上中签率（%，100 倍整数）
+	// f163: 募资总额（万元）
+	// f167: 换手率（%，100 倍整数）
+	// f2:   最新价
+	// f3:   涨跌幅（%，100 倍整数）
+	// f4:   涨跌额
+
+	// 已上市新股列表的 fs 参数
+	// m:0 沪深 + s:2048 北交所 + t:80 上交所主板 + t:81 深交所主板
+	ipoFS = "m:0+t:80+t:81+s:2048"
+
+	// 排序字段：f26 = 按上市日期
+	ipoSortField = "f26"
+
+	browserUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" +
+		" AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+// IPO 单条记录
+type IListing struct {
+	Code         string `json:"code"`           // 证券代码
+	Name         string `json:"name"`           // 证券简称
+	ListingDate  string `json:"listing_date"`   // 上市日期 (YYYYMMDD / -)
+	PurchaseCode string `json:"purchase_code"`  // 申购代码（东方财富列表中不存在此字段，暂留）
+	PurchaseName string `json:"purchase_name"`  // 申购简称（同上）
+	Date         string `json:"date,omitempty"` // YYYY-MM-DD 格式，来自请求参数或接口返回
+}
+
+// IPOListReq 新股列表查询参数
+type IPOListReq struct {
+	SortDesc bool // 排序方向：true=倒序（近到远），false=正序（远到近）
+	PageNum  int  // 页码，从 1 开始
+	PageSize int  // 每页条数（东财上限 5000）
+	MaxTotal int  // 最大获取条数；0 表示按 PageSize 取一页
+}
+
+// ListIPOResponse 东财新股列表返回原始结构
+type ListIPOResponse struct {
+	Rc   int             `json:"rc"`
+	Data *IPOListRawData `json:"data"`
+}
+
+// IPOListRawData 新股列表 data 字段
+type IPOListRawData struct {
+	Total int                      `json:"total"`
+	Diff  []map[string]interface{} `json:"diff"`
+}
+
+// ListIPO 获取东方财富新股列表（已上市新股 + 待上市新股）
+func ListIPO(ctx context.Context, req *IPOListReq) ([]*IListing, int, error) {
+	if req == nil {
+		req = &IPOListReq{}
+	}
+	pageSize := req.PageSize
+	if pageSize <= 0 || pageSize > 5000 {
+		pageSize = 30
+	}
+	pageNum := req.PageNum
+	if pageNum <= 0 {
+		pageNum = 1
+	}
+
+	items := make([]*IListing, 0)
+	maxItems := req.MaxTotal
+	if maxItems <= 0 {
+		maxItems = pageSize
+	}
+
+	var firstTotal int
+	for {
+		batch, total, err := fetchIPOListBatch(ctx, pageNum, pageSize)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if len(items) == 0 {
+			firstTotal = total
+		}
+		items = append(items, batch...)
+		if len(items) >= maxItems || len(batch) < pageSize {
+			break
+		}
+		pageNum++
+	}
+	if len(items) > maxItems {
+		items = items[:maxItems]
+	}
+	return items, firstTotal, nil
+}
+
+func fetchIPOListBatch(ctx context.Context, pageNum, pageSize int) ([]*IListing, int, error) {
+	po := "1"
+	if pageNum > 0 {
+		// "po" 没有正式文档，观测经验：1 表示倒序（最近上市在前）
+		po = "1"
+	}
+
+	v := url.Values{}
+	v.Set("pn", strconv.Itoa(pageNum))
+	v.Set("pz", strconv.Itoa(pageSize))
+	v.Set("np", "1")
+	v.Set("fltt", "2")
+	v.Set("invt", "2")
+	v.Set("fid", ipoSortField)
+	v.Set("po", po)
+	v.Set("fs", ipoFS)
+	v.Set("fields", ipoFields)
+
+	reqURL := ipoURL + "?" + v.Encode()
+	// 东方财富 push2 要求浏览器 UA + Referer 才能正常返回；偶发 EOF 时自动重试
+	headers := http.Header{}
+	headers.Set("User-Agent", browserUA)
+	headers.Set("Referer", "http://data.eastmoney.com/xg/xg/default.html")
+	headers.Set("Accept", "*/*")
+	client := newHTTPClient(defaultTimeout)
+	var resp *http.Response
+	var err error
+	for attempt := 1; attempt <= 5; attempt++ {
+		resp, err = doRequest(ctx, client, http.MethodGet, reqURL, headers, nil)
+		if err == nil {
+			break
+		}
+		slog.ErrorContext(ctx, "failed fetchIPOListBatch", "attempt", attempt, "error", err)
+		if attempt < 5 {
+			// 指数退避：1s, 2s, 4s, 8s
+			backoff := time.Duration(1<<(attempt-1)) * time.Second
+			select {
+			case <-ctx.Done():
+				slog.WarnContext(ctx, "fetchIPOListBatch ctx.Done")
+				return nil, 0, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("eastMoney IPO list request (5 attempts): %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed read body", "error", err)
+		return nil, 0, err
+	}
+
+	var raw ListIPOResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, 0, fmt.Errorf("eastMoney IPO list parse: %w", err)
+	}
+	if raw.Data == nil {
+		return nil, 0, fmt.Errorf("eastMoney IPO list: nil data")
+	}
+
+	listings := make([]*IListing, 0, len(raw.Data.Diff))
+	for _, item := range raw.Data.Diff {
+		listing, err := parseIPOListItem(item)
+		if err != nil {
+			continue
+		}
+		listings = append(listings, listing)
+	}
+	return listings, raw.Data.Total, nil
+}
+
+func parseIPOListItem(m map[string]interface{}) (*IListing, error) {
+	code := getStrField(m, "f12")
+	name := getStrField(m, "f14")
+	if code == "" || code == "-" {
+		return nil, fmt.Errorf("invalid IPO item: empty code")
+	}
+
+	listingDateString := getStrField(m, "f26")
+	var listingDate time.Time
+	if listingDateString != "-" && listingDateString != "" {
+		// 东财 f26 字段可能是整数 20260702 或 "20260702" 字符串
+		parsedDate, err := time.Parse("20060102", listingDateString)
+		if err != nil {
+			// 尝试从 float 解析
+			if f, ok := listingDateString2Float(listingDateString); ok {
+				listingDateString = strconv.FormatInt(int64(math.Round(f)), 10)
+			}
+			parsedDate, err = time.Parse("20060102", listingDateString)
+			if err != nil {
+				listingDate = time.Time{}
+			} else {
+				listingDate = parsedDate
+			}
+		} else {
+			listingDate = parsedDate
+		}
+	}
+	ListingDateString := listingDateString
+	if !listingDate.IsZero() {
+		ListingDateString = listingDate.Format("20060102")
+	}
+
+	return &IListing{
+		Code:         code,
+		Name:         name,
+		ListingDate:  ListingDateString,
+		PurchaseCode: getStrField(m, "f57"),
+		PurchaseName: getStrField(m, "f58"),
+	}, nil
+}
+
+// listingDateString2Float 将形如 "20260702" 的字符串转 float（float 模式）
+func listingDateString2Float(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return f, true
+}
+
+// StrField 从 map 提取字符串字段
+func getStrField(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		if strings.TrimSpace(x) == "-" || strings.TrimSpace(x) == "" {
+			return "-"
+		}
+		return strings.TrimSpace(x)
+	case float64:
+		if x == 0 {
+			return "-"
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", v))
+	}
+}
+
+// Float64Field 从 map 提取 float64 字段
+func getFloat64Field(m map[string]interface{}, key string) float64 {
+	v, ok := m[key]
+	if !ok {
+		return -1
+	}
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int64:
+		return float64(x)
+	case int:
+		return float64(x)
+	case string:
+		if x == "-" || x == "" {
+			return -1
+		}
+		f, err := strconv.ParseFloat(x, 64)
+		if err != nil {
+			return -1
+		}
+		return f
+	default:
+		return -1
+	}
+}

--- a/provider/eastmoney/ipo_test.go
+++ b/provider/eastmoney/ipo_test.go
@@ -1,0 +1,428 @@
+package eastmoney
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+/* ------------------------- parseIPOListItem ------------------------- */
+
+func TestParseIPOListItem(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]interface{}
+		want    *IListing
+		wantErr bool
+	}{
+		{
+			name: "valid item with integer listing date",
+			input: map[string]interface{}{
+				"f12": "920193",
+				"f14": "吉和昌",
+				"f26": float64(20260702),
+			},
+			want: &IListing{
+				Code:        "920193",
+				Name:        "吉和昌",
+				ListingDate: "20260702",
+			},
+		},
+		{
+			name: "valid item with string listing date",
+			input: map[string]interface{}{
+				"f12": "300750",
+				"f14": "宁德时代",
+				"f26": "20180611",
+			},
+			want: &IListing{
+				Code:        "300750",
+				Name:        "宁德时代",
+				ListingDate: "20180611",
+			},
+		},
+		{
+			name: "item with - listing date (forthcoming)",
+			input: map[string]interface{}{
+				"f12": "920222",
+				"f14": "某新股",
+				"f26": "-",
+			},
+			want: &IListing{
+				Code:        "920222",
+				Name:        "某新股",
+				ListingDate: "-",
+			},
+		},
+		{
+			name: "empty code returns error",
+			input: map[string]interface{}{
+				"f12": "",
+				"f14": "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "code = - returns error",
+			input: map[string]interface{}{
+				"f12": "-",
+				"f14": "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing listing date field",
+			input: map[string]interface{}{
+				"f12": "600036",
+				"f14": "招商银行",
+			},
+			want: &IListing{
+				Code:        "600036",
+				Name:        "招商银行",
+				ListingDate: "",
+			},
+		},
+		{
+			name: "item carrying purchase code / name (kept for forward-compat)",
+			input: map[string]interface{}{
+				"f12": "688806",
+				"f14": "泰诺麦博",
+				"f26": float64(20260701),
+				"f57": "787806",
+				"f58": "泰诺麦博申购",
+			},
+			want: &IListing{
+				Code:         "688806",
+				Name:         "泰诺麦博",
+				ListingDate:  "20260701",
+				PurchaseCode: "787806",
+				PurchaseName: "泰诺麦博申购",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIPOListItem(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+/* ------------------------- str / float field helpers ------------------------- */
+
+func TestGetStrField(t *testing.T) {
+	m := map[string]interface{}{
+		"str":   "hello",
+		"dash":  "-",
+		"empty": "",
+		"num":   float64(42),
+		"zero":  float64(0),
+	}
+
+	require.Equal(t, "hello", getStrField(m, "str"))
+	require.Equal(t, "-", getStrField(m, "dash"))
+	require.Equal(t, "-", getStrField(m, "empty"))
+	require.Equal(t, "42", getStrField(m, "num"))
+	require.Equal(t, "-", getStrField(m, "zero"))
+	require.Equal(t, "", getStrField(m, "missing"))
+}
+
+func TestGetFloat64Field(t *testing.T) {
+	m := map[string]interface{}{
+		"f":    float64(123.45),
+		"i":    int64(7),
+		"i2":   int(8),
+		"s":    "3.14",
+		"dash": "-",
+		"bad":  "not-a-number",
+	}
+
+	require.InDelta(t, 123.45, getFloat64Field(m, "f"), 1e-9)
+	require.InDelta(t, 7.0, getFloat64Field(m, "i"), 1e-9)
+	require.InDelta(t, 8.0, getFloat64Field(m, "i2"), 1e-9)
+	require.InDelta(t, 3.14, getFloat64Field(m, "s"), 1e-9)
+	require.InDelta(t, -1.0, getFloat64Field(m, "dash"), 1e-9)
+	require.InDelta(t, -1.0, getFloat64Field(m, "bad"), 1e-9)
+	require.InDelta(t, -1.0, getFloat64Field(m, "missing"), 1e-9)
+}
+
+func TestListingDateString2Float(t *testing.T) {
+	f, ok := listingDateString2Float("20260702")
+	require.True(t, ok)
+	require.InDelta(t, 20260702.0, f, 1e-9)
+
+	_, ok = listingDateString2Float("not-a-date")
+	require.False(t, ok)
+}
+
+/* ------------------------- fetchIPOListBatch with mock server ------------------------- */
+
+const sampleIPOListJSON = `{
+    "rc": 0,
+    "rt": 6,
+    "svr": 183120374,
+    "lt": 1,
+    "full": 1,
+    "dlmkts": "",
+    "dsc": "0",
+    "data": {
+        "total": 3,
+        "diff": [
+            {"f12": "920193", "f14": "吉和昌", "f26": 20260702, "f57": "787193", "f58": "吉和昌申购"},
+            {"f12": "920222", "f14": "益坤电气", "f26": 20260630, "f57": "-", "f58": "-"},
+            {"f12": "920072", "f14": "科莱瑞迪", "f26": 20260629}
+        ]
+    }
+}`
+
+func newTestServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	return srv
+}
+
+func TestFetchIPOListBatch(t *testing.T) {
+	srv := newTestServer(t, sampleIPOListJSON)
+	defer srv.Close()
+
+	// 用 httptest URL 替换 ipoURL（包级变量，测试结束恢复）
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, total, err := fetchIPOListBatch(context.Background(), 1, 30)
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+	require.Len(t, items, 3)
+
+	require.Equal(t, "920193", items[0].Code)
+	require.Equal(t, "吉和昌", items[0].Name)
+	require.Equal(t, "20260702", items[0].ListingDate)
+	require.Equal(t, "787193", items[0].PurchaseCode)
+	require.Equal(t, "吉和昌申购", items[0].PurchaseName)
+
+	require.Equal(t, "920072", items[2].Code)
+	require.Equal(t, "20260629", items[2].ListingDate)
+}
+
+func TestFetchIPOListBatchServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	// 无效 JSON / 错误 status 会走到 Unmarshal 失败
+	_, _, err := fetchIPOListBatch(context.Background(), 1, 30)
+	require.Error(t, err)
+}
+
+/* ------------------------- ListIPO (multi-page + max total) ------------------------- */
+
+// newMultiPageServer 返回 total=5、每页 3 条的 fake server
+func newMultiPageServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	responseForPage := func(page int) string {
+		start := []map[string]interface{}{
+			{"f12": "001", "f14": "新股1", "f26": float64(20260701)},
+			{"f12": "002", "f14": "新股2", "f26": float64(20260630)},
+			{"f12": "003", "f14": "新股3", "f26": float64(20260629)},
+		}
+		if page == 1 {
+			_ = start
+		} else {
+			start = []map[string]interface{}{
+				{"f12": "004", "f14": "新股4", "f26": float64(20260628)},
+				{"f12": "005", "f14": "新股5", "f26": float64(20260627)},
+			}
+		}
+		total := 5
+		if page > 1 {
+			total = 0 // 仅第一页返回 total
+		}
+		data := map[string]interface{}{
+			"rc": 0,
+			"data": map[string]interface{}{
+				"total": total,
+				"diff":  start,
+			},
+		}
+		b, _ := json.Marshal(data)
+		return string(b)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pn := r.URL.Query().Get("pn")
+		resp := responseForPage(1)
+		if pn == "2" || pn == "02" {
+			resp = responseForPage(2)
+		}
+		_, _ = io.WriteString(w, resp)
+	}))
+	return srv
+}
+
+func TestListIPO_OnePage(t *testing.T) {
+	// mock server：第一页 3 条，第二页 2 条（第一页 total=5）。
+	// MaxTotal=10 > 3 → 第一页满后继续拉第二页，共 5 条。
+	srv := newMultiPageServer(t)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, total, err := ListIPO(context.Background(), &IPOListReq{
+		PageNum:  1,
+		PageSize: 3,
+		MaxTotal: 10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 5, total) // 实现返回 total=0；保持行为稳定
+	require.Len(t, items, 5)   // 拉满两页（3 + 2）
+}
+
+func TestListIPO_MaxTotalCapped(t *testing.T) {
+	srv := newMultiPageServer(t)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, _, err := ListIPO(context.Background(), &IPOListReq{
+		PageNum:  1,
+		PageSize: 3,
+		MaxTotal: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+}
+
+func TestListIPO_NilReq(t *testing.T) {
+	srv := newMultiPageServer(t)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, _, err := ListIPO(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+}
+
+func TestListIPO_SinglePageShortBatch(t *testing.T) {
+	// mock server（pageSize=30 但服务器仅返回 3 条）→ ListIPO 在 len(batch) < pageSize 时退出
+	body := `{
+		"rc": 0,
+		"data": {
+			"total": 3,
+			"diff": [
+				{"f12": "001", "f14": "新股1", "f26": 20260701},
+				{"f12": "002", "f14": "新股2", "f26": 20260630},
+				{"f12": "003", "f14": "新股3", "f26": 20260629}
+			]
+		}
+	}`
+	srv := newTestServer(t, body)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, _, err := ListIPO(context.Background(), &IPOListReq{
+		PageNum:  1,
+		PageSize: 30,
+		MaxTotal: 0,
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 3) // 服务端返回 3 条即退出（len(batch) < pageSize）
+}
+
+/* ------------------------- fetchIPOListBatch handling empty / malformed body ------------------------- */
+
+func TestFetchIPOListBatchEmptyDiff(t *testing.T) {
+	body := `{"rc":0,"data":{"total":0,"diff":[]}}`
+	srv := newTestServer(t, body)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, total, err := fetchIPOListBatch(context.Background(), 1, 30)
+	require.NoError(t, err)
+	require.Equal(t, 0, total)
+	require.Empty(t, items)
+}
+
+func TestFetchIPOListBatchSkipsInvalidItems(t *testing.T) {
+	body := `{
+		"rc": 0,
+		"data": {
+			"total": 3,
+			"diff": [
+				{"f12": "-", "f14": "bad", "f26": "-"},
+				{"f12": "",  "f14": "bad2"},
+				{"f12": "123456", "f14": "good", "f26": "20260702"}
+			]
+		}
+	}`
+	srv := newTestServer(t, body)
+	defer srv.Close()
+
+	origURL := ipoURL
+	ipoURL = srv.URL + "/api/qt/clist/get"
+	defer func() { ipoURL = origURL }()
+
+	items, _, err := fetchIPOListBatch(context.Background(), 1, 30)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "123456", items[0].Code)
+}
+
+/* ------------------------- URL query parameters (sanity) ------------------------- */
+
+func TestIPOListReq_URLFields(t *testing.T) {
+	// 直接构造一个 fetchIPOListBatch 使用的 url.Values，
+	// 校验关键查询参数是否正确。
+	v := url.Values{}
+	v.Set("pn", "1")
+	v.Set("pz", "30")
+	v.Set("np", "1")
+	v.Set("fltt", "2")
+	v.Set("invt", "2")
+	v.Set("fid", ipoSortField)
+	v.Set("po", "1")
+	v.Set("fs", ipoFS)
+	v.Set("fields", ipoFields)
+
+	require.Equal(t, "f26", v.Get("fid"))
+	require.Equal(t, "1", v.Get("po"))
+	require.Equal(t, "m:0+t:80+t:81+s:2048", v.Get("fs"))
+	require.NotEmpty(t, v.Get("fields"))
+	require.Contains(t, v.Get("fields"), "f12")
+	require.Contains(t, v.Get("fields"), "f26")
+	require.Contains(t, v.Get("fields"), "f14")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sec ipo` CLI commands for IPO listings, schedule/calendar lookup, and prospectus/PDF discovery.
  * Expanded IPO data sourcing from additional Eastmoney and CNINFO categories, including direct prospectus PDF links.
* **Bug Fixes**
  * Improved resilience of IPO fetching and better handling of empty or missing IPO/prospectus fields in command output.
* **Documentation**
  * Added `research-ipo.md` with a data-source overview and implementation approach.
* **Tests**
  * Added unit and HTTP-mocked tests for IPO calendar/listing parsing, pagination, filtering, and PDF URL resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->