### PR TITLE
ipo: download ipo pdf

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,9 @@
       "WebFetch(domain:push2.eastmoney.com)",
       "Bash(/tmp/sec ipo *)",
       "Bash(gofmt -w provider/eastmoney/ipo_test.go)",
-      "Bash(gofmt -l provider/eastmoney/)"
+      "Bash(gofmt -l provider/eastmoney/)",
+      "Bash(go version *)",
+      "Bash(go env *)"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## sec change log
 
+### v0.3.11
+
+1. 新增 `sec ipo download` 命令：支持交互选择、批量下载、指定编号下载招股说明书 PDF
+2. 数据来源：巨潮资讯 cninfo（复用 `cninfo.QueryIPOs` + `cninfo.DownloadPDF`）
+3. 提取 `resolveStock` 公共函数，供 `prospectus` 和 `download` 命令共用
+4. 支持 `--all`（全部下载）、`--index`（指定编号）、`--force`（覆盖已有）、`--dry-run`（预览）、`-o`（输出目录）等参数
+
 ### v0.3.10
 
 1. 修复依赖报错 https://github.com/alwqx/sec/security/dependabot/3

--- a/cmd/ipo/download.go
+++ b/cmd/ipo/download.go
@@ -1,0 +1,365 @@
+package ipo
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/alwqx/sec/provider/cninfo"
+	"github.com/alwqx/sec/utils"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+// newDownloadCmd creates the `sec ipo download` subcommand.
+func newDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download <code>",
+		Short: "Download IPO prospectus (招股说明书) PDFs for a stock",
+		Long: "Query IPO-related announcements (招股意向书/招股说明书/发行公告) from CNINFO " +
+			"for the given stock code and download the PDF files.\n" +
+			"Without --all or --index, enters interactive selection mode.",
+		Aliases: []string{"dl", "d"},
+		Example: `  sec ipo download 300750                    # interactive selection
+  sec ipo download 300750 --all               # download all prospectuses
+  sec ipo download 300750 --index 1           # download the first (latest) one
+  sec ipo download 300750 -i 1,3,5            # download specific items
+  sec ipo download 300750 -o ./prospectuses   # save to directory
+  sec ipo download 300750 --dry-run           # preview only
+  sec ipo download 300750 --since 2018-01-01 --until 2018-12-31 --all`,
+		Args: cobra.ExactArgs(1),
+		RunE: runDownload,
+	}
+	cmd.Flags().BoolP("debug", "D", false, "Enable debug mode")
+	cmd.Flags().IntP("size", "n", 30, "Maximum number of announcements to query")
+	cmd.Flags().StringP("output-dir", "o", ".", "Directory to save downloaded PDFs")
+	cmd.Flags().BoolP("all", "a", false, "Download all matching prospectus PDFs")
+	cmd.Flags().StringP("index", "i", "", "Download specific items by number (comma-separated, 1-based), e.g. 1,3,5")
+	cmd.Flags().Bool("force", false, "Overwrite existing files")
+	cmd.Flags().Bool("dry-run", false, "Preview only (list without downloading)")
+	cmd.Flags().String("since", "", "Only show/download prospectuses on or after this date (YYYY-MM-DD)")
+	cmd.Flags().String("until", "", "Only show/download prospectuses on or before this date (YYYY-MM-DD)")
+	return cmd
+}
+
+func runDownload(cmd *cobra.Command, args []string) error {
+	code := args[0]
+	size, _ := cmd.Flags().GetInt("size")
+	if size <= 0 {
+		size = 30
+	}
+	if size > 5000 {
+		size = 5000
+	}
+	outputDir, _ := cmd.Flags().GetString("output-dir")
+	all, _ := cmd.Flags().GetBool("all")
+	indexStr, _ := cmd.Flags().GetString("index")
+	force, _ := cmd.Flags().GetBool("force")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	since, _ := cmd.Flags().GetString("since")
+	until, _ := cmd.Flags().GetString("until")
+
+	ctx := cmd.Context()
+
+	stockCode, orgID, secName, err := resolveStock(ctx, code)
+	if err != nil {
+		return err
+	}
+
+	stockParam := fmt.Sprintf("%s,%s", stockCode, orgID)
+	announcements, err := cninfo.QueryIPOs(ctx, stockParam, size)
+	if err != nil {
+		return fmt.Errorf("查询招股书失败: %w", err)
+	}
+
+	if len(announcements) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "未找到 %s (%s) 的 IPO 公告（cninfo 可能未收录或代码有误）\n", secName, stockCode)
+		return nil
+	}
+
+	// Filter by date
+	filtered := filterByDate(announcements, since, until)
+	// Filter out invalid/cancelled announcements
+	valid := filterValidPDFs(filtered)
+
+	if len(valid) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s (%s) 没有符合条件的招股书 PDF\n", secName, stockCode)
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\n%s (%s) IPO 相关公告 (来源: 巨潮资讯 cninfo.com.cn)\n\n", secName, stockCode)
+
+	// Always show the list
+	printDownloadList(out, valid)
+
+	if dryRun {
+		fmt.Fprintln(out)
+		return nil
+	}
+
+	slog.DebugContext(ctx, "ipo download: entering selection", "count", len(valid))
+
+	// Determine which items to download
+	var selected []int
+	switch {
+	case all:
+		for i := range valid {
+			selected = append(selected, i)
+		}
+	case indexStr != "":
+		selected, err = parseIndexList(indexStr, len(valid))
+		if err != nil {
+			return fmt.Errorf("invalid --index: %w", err)
+		}
+	default:
+		// Interactive mode
+		selected, err = promptSelection(out, cmd.InOrStdin(), len(valid))
+		if err != nil {
+			return fmt.Errorf("选择失败: %w", err)
+		}
+		if len(selected) == 0 {
+			fmt.Fprintln(out, "已取消")
+			return nil
+		}
+	}
+
+	slog.DebugContext(ctx, "ipo download: selection done", "selected", selected)
+
+	if len(selected) == 0 {
+		fmt.Fprintln(out, "没有选中任何文件")
+		return nil
+	}
+
+	// Download
+	fmt.Fprintf(out, "\n开始下载到 %s ...\n\n", outputDir)
+	downloaded, skipped, failed := 0, 0, 0
+
+	for _, idx := range selected {
+		a := valid[idx]
+		filename := buildFilename(stockCode, secName, a)
+		destPath := filepath.Join(outputDir, filename)
+
+		idxDisplay := downloaded + skipped + failed + 1
+
+		// Check if file exists
+		if !force {
+			if _, statErr := os.Stat(destPath); statErr == nil {
+				fmt.Fprintf(out, "  [%d/%d] %s\n      已存在，跳过\n", idxDisplay, len(selected), filename)
+				skipped++
+				continue
+			}
+		}
+
+		fmt.Fprintf(out, "  [%d/%d] 下载: %s\n", idxDisplay, len(selected), filename)
+
+		dlErr := downloadOne(ctx, a, destPath)
+		if dlErr != nil {
+			fmt.Fprintf(out, "      失败: %v\n", dlErr)
+			failed++
+			continue
+		}
+
+		sizeStr := ""
+		if a.AdjunctSize > 0 {
+			sizeStr = fmt.Sprintf(" (%s)", utils.HumanByte(float64(a.AdjunctSize)))
+		}
+		fmt.Fprintf(out, "      完成%s\n", sizeStr)
+		downloaded++
+	}
+
+	fmt.Fprintf(out, "\n下载完成: %d 新下载, %d 跳过, %d 失败\n", downloaded, skipped, failed)
+	return nil
+}
+
+// filterValidPDFs filters out announcements with invalid flags or non-PDF adjuncts.
+func filterValidPDFs(announcements []*cninfo.Announcement) []*cninfo.Announcement {
+	out := make([]*cninfo.Announcement, 0, len(announcements))
+	for _, a := range announcements {
+		if a.ExistFlag != 0 || a.InvalidationFlag != 0 {
+			continue
+		}
+		// Skip if no adjunct URL (can't download)
+		if a.AdjunctURL == "" {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// printDownloadList renders the announcement list with index numbers for selection.
+func printDownloadList(out io.Writer, announcements []*cninfo.Announcement) {
+	table := tablewriter.NewWriter(out)
+	headers := []string{"#", "公告日期", "公告标题", "大小"}
+	table.SetHeader(headers)
+	headerStyles := make([]tablewriter.Colors, len(headers))
+	for i := range headers {
+		headerStyles[i] = tablewriter.Colors{tablewriter.Bold}
+	}
+	table.SetHeaderColor(headerStyles...)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding("\t")
+
+	for i, a := range announcements {
+		sizeStr := "-"
+		if a.AdjunctSize > 0 {
+			sizeStr = utils.HumanByte(float64(a.AdjunctSize))
+		}
+		title := a.Title
+		if len([]rune(title)) > 60 {
+			title = string([]rune(title)[:57]) + "..."
+		}
+
+		date := a.Date
+		if len(date) == 8 {
+			date = date[:4] + "-" + date[4:6] + "-" + date[6:]
+		}
+
+		idxStr := strconv.Itoa(i + 1)
+		styles := make([]tablewriter.Colors, len(headers))
+		if strings.Contains(title, "招股") {
+			styles[2] = tablewriter.Colors{tablewriter.Bold}
+		}
+		row := []string{idxStr, date, title, sizeStr}
+		table.Rich(row, styles)
+	}
+	table.Render()
+}
+
+// parseIndexList parses a comma-separated list of 1-based indices.
+func parseIndexList(s string, max int) ([]int, error) {
+	parts := strings.Split(s, ",")
+	seen := make(map[int]bool)
+	var out []int
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid index %q: must be a number", p)
+		}
+		if n < 1 || n > max {
+			return nil, fmt.Errorf("index %d out of range [1, %d]", n, max)
+		}
+		if !seen[n] {
+			seen[n] = true
+			out = append(out, n-1) // convert to 0-based
+		}
+	}
+	return out, nil
+}
+
+// promptSelection displays a prompt and reads the user's selection from stdin.
+func promptSelection(out io.Writer, in io.Reader, max int) ([]int, error) {
+	fmt.Fprintf(out, "\n请选择要下载的编号 (all=全部, q=退出, 默认=1):\n")
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("读取输入失败: %w", err)
+	}
+	line = strings.TrimSpace(line)
+
+	// Default: first item
+	if line == "" {
+		return []int{0}, nil
+	}
+
+	// Quit
+	if strings.ToLower(line) == "q" || strings.ToLower(line) == "quit" {
+		return nil, nil
+	}
+
+	// All
+	if strings.ToLower(line) == "all" || strings.ToLower(line) == "a" {
+		var all []int
+		for i := 0; i < max; i++ {
+			all = append(all, i)
+		}
+		return all, nil
+	}
+
+	return parseIndexList(line, max)
+}
+
+// downloadOne downloads a single announcement PDF.
+func downloadOne(ctx context.Context, a *cninfo.Announcement, destPath string) error {
+	// Ensure output directory exists
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+	return cninfo.DownloadPDF(ctx, a.AdjunctURL, destPath)
+}
+
+// titleKeywords lists recognized prospectus title patterns, ordered by priority.
+var titleKeywords = []string{
+	"招股说明书",
+	"招股意向书",
+	"上市公告书",
+	"发行公告",
+}
+
+// extractShortTitle extracts a short, filesystem-safe label from an announcement title.
+func extractShortTitle(title string) string {
+	for _, kw := range titleKeywords {
+		if strings.Contains(title, kw) {
+			return kw
+		}
+	}
+	// Fallback: look for "招股" more broadly
+	if strings.Contains(title, "招股") {
+		return "招股书"
+	}
+	// Generic: use first N chars of title
+	runes := []rune(title)
+	if len(runes) > 15 {
+		return string(runes[:15])
+	}
+	return title
+}
+
+// buildFilename constructs a PDF filename from stock info and announcement.
+// Format: {code}_{name}_{shortTitle}_{date}.pdf
+func buildFilename(code, name string, a *cninfo.Announcement) string {
+	shortTitle := extractShortTitle(a.Title)
+	date := a.Date
+	if len(date) == 0 && a.Time > 0 {
+		date = fmt.Sprintf("%d", a.Time/1000)
+	}
+	raw := fmt.Sprintf("%s_%s_%s_%s", code, name, shortTitle, date)
+	safe := sanitizeFilename(raw)
+	return safe + ".pdf"
+}
+
+// sanitizeFilename replaces characters that are illegal in Windows/macOS/Linux filenames.
+func sanitizeFilename(name string) string {
+	// Characters illegal on Windows: < > : " / \ | ? *
+	// Also replace newlines and tabs
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+		"\n", "",
+		"\r", "",
+		"\t", " ",
+	)
+	return replacer.Replace(name)
+}

--- a/cmd/ipo/download_test.go
+++ b/cmd/ipo/download_test.go
@@ -1,0 +1,667 @@
+package ipo
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/alwqx/sec/provider/cninfo"
+)
+
+/* ------------------------------------------------------------------ */
+/* promptSelection                                                     */
+/* ------------------------------------------------------------------ */
+
+func TestPromptSelection_DefaultEmptyInput(t *testing.T) {
+	var out bytes.Buffer
+	// 用户直接按回车 → 默认选第 1 条
+	in := strings.NewReader("\n")
+	got, err := promptSelection(&out, in, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("expected [0] (default=1), got %v", got)
+	}
+	// 检查提示信息已写入
+	if !strings.Contains(out.String(), "请选择") {
+		t.Fatalf("expected prompt in output, got: %s", out.String())
+	}
+}
+
+func TestPromptSelection_QuitLower(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("q\n")
+	got, err := promptSelection(&out, in, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for quit, got %v", got)
+	}
+}
+
+func TestPromptSelection_QuitFullWord(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("quit\n")
+	got, err := promptSelection(&out, in, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for quit, got %v", got)
+	}
+}
+
+func TestPromptSelection_QuitCaseInsensitive(t *testing.T) {
+	for _, input := range []string{"Q\n", "QUIT\n", "Quit\n", "qUiT\n"} {
+		var out bytes.Buffer
+		in := strings.NewReader(input)
+		got, err := promptSelection(&out, in, 5)
+		if err != nil {
+			t.Fatalf("input %q: unexpected error: %v", input, err)
+		}
+		if got != nil {
+			t.Fatalf("input %q: expected nil for quit, got %v", input, got)
+		}
+	}
+}
+
+func TestPromptSelection_AllLower(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("all\n")
+	got, err := promptSelection(&out, in, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1, 2}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i, v := range got {
+		if v != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_AllShortAlias(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("a\n")
+	got, err := promptSelection(&out, in, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1, 2, 3}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i, v := range got {
+		if v != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_AllCaseInsensitive(t *testing.T) {
+	for _, input := range []string{"ALL\n", "All\n", "aLl\n"} {
+		var out bytes.Buffer
+		in := strings.NewReader(input)
+		got, err := promptSelection(&out, in, 2)
+		if err != nil {
+			t.Fatalf("input %q: unexpected error: %v", input, err)
+		}
+		expected := []int{0, 1}
+		if len(got) != len(expected) {
+			t.Fatalf("input %q: expected %v, got %v", input, expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_AliasCaseInsensitive(t *testing.T) {
+	for _, input := range []string{"A\n"} {
+		var out bytes.Buffer
+		in := strings.NewReader(input)
+		got, err := promptSelection(&out, in, 2)
+		if err != nil {
+			t.Fatalf("input %q: unexpected error: %v", input, err)
+		}
+		expected := []int{0, 1}
+		if len(got) != len(expected) {
+			t.Fatalf("input %q: expected %v, got %v", input, expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_SingleIndex(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("1\n")
+	got, err := promptSelection(&out, in, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("expected [0] for index 1, got %v", got)
+	}
+}
+
+func TestPromptSelection_SingleIndexMiddle(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("3\n")
+	got, err := promptSelection(&out, in, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("expected [2] for index 3, got %v", got)
+	}
+}
+
+func TestPromptSelection_MultipleIndices(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("1,3,5\n")
+	got, err := promptSelection(&out, in, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 2, 4}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i, v := range got {
+		if v != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_IndicesWithSpaces(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader(" 1 ,  3  , 5 \n")
+	got, err := promptSelection(&out, in, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 2, 4}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i, v := range got {
+		if v != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestPromptSelection_OutOfRange(t *testing.T) {
+	var out bytes.Buffer
+	// max=3 → 只有序号 1,2,3 有效；10 越界
+	in := strings.NewReader("10\n")
+	_, err := promptSelection(&out, in, 3)
+	if err == nil {
+		t.Fatal("expected error for out-of-range index")
+	}
+}
+
+func TestPromptSelection_NonNumeric(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("abc\n")
+	_, err := promptSelection(&out, in, 5)
+	if err == nil {
+		t.Fatal("expected error for non-numeric input")
+	}
+}
+
+func TestPromptSelection_AllWithMaxOne(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("all\n")
+	got, err := promptSelection(&out, in, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0}
+	if len(got) != len(expected) || got[0] != expected[0] {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestPromptSelection_TrailingSpaces(t *testing.T) {
+	var out bytes.Buffer
+	// "1  \n" → trim 后 "1" → index 0
+	in := strings.NewReader("1  \n")
+	got, err := promptSelection(&out, in, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("expected [0], got %v", got)
+	}
+}
+
+func TestPromptSelection_ZeroNotAllowed(t *testing.T) {
+	var out bytes.Buffer
+	// 0 号不在 1-based 范围
+	in := strings.NewReader("0\n")
+	_, err := promptSelection(&out, in, 5)
+	if err == nil {
+		t.Fatal("expected error for index 0")
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* parseIndexList                                                      */
+/* ------------------------------------------------------------------ */
+
+func TestParseIndexList_Normal(t *testing.T) {
+	got, err := parseIndexList("1,2,3", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1, 2}
+	assertIntSlice(t, got, expected)
+}
+
+func TestParseIndexList_Single(t *testing.T) {
+	got, err := parseIndexList("1", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0}
+	assertIntSlice(t, got, expected)
+}
+
+func TestParseIndexList_WithSpaces(t *testing.T) {
+	got, err := parseIndexList(" 1 , 2 , 3 ", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1, 2}
+	assertIntSlice(t, got, expected)
+}
+
+func TestParseIndexList_Deduplication(t *testing.T) {
+	// "1,1,2" → dedup → [0,1]
+	got, err := parseIndexList("1,1,2", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1}
+	assertIntSlice(t, got, expected)
+}
+
+func TestParseIndexList_DeduplicationWithSpaces(t *testing.T) {
+	got, err := parseIndexList("1, 2, 1, 3, 2", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 1, 2}
+	assertIntSlice(t, got, expected)
+}
+
+func TestParseIndexList_EmptyString(t *testing.T) {
+	got, err := parseIndexList("", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestParseIndexList_OnlyCommas(t *testing.T) {
+	got, err := parseIndexList(",,,", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestParseIndexList_ZeroOutOfRange(t *testing.T) {
+	_, err := parseIndexList("0", 10)
+	if err == nil {
+		t.Fatal("expected error for index 0 (1-based)")
+	}
+}
+
+func TestParseIndexList_OutOfRange(t *testing.T) {
+	_, err := parseIndexList("10", 5)
+	if err == nil {
+		t.Fatal("expected error for out-of-range index")
+	}
+}
+
+func TestParseIndexList_Negative(t *testing.T) {
+	_, err := parseIndexList("-1", 10)
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+}
+
+func TestParseIndexList_NonNumeric(t *testing.T) {
+	_, err := parseIndexList("abc", 10)
+	if err == nil {
+		t.Fatal("expected error for non-numeric input")
+	}
+}
+
+func TestParseIndexList_MixedValidInvalid(t *testing.T) {
+	_, err := parseIndexList("1,abc,3", 10)
+	if err == nil {
+		t.Fatal("expected error for mixed valid/invalid")
+	}
+}
+
+func TestParseIndexList_MaxBoundary(t *testing.T) {
+	// max 有效值
+	got, err := parseIndexList("5", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != 4 {
+		t.Fatalf("expected [4], got %v", got)
+	}
+
+	// max+1 越界
+	_, err = parseIndexList("6", 5)
+	if err == nil {
+		t.Fatal("expected error for max+1")
+	}
+}
+
+func TestParseIndexList_MaintainsOrder(t *testing.T) {
+	// 去重但保持首次出现顺序
+	got, err := parseIndexList("3,1,2", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{2, 0, 1}
+	assertIntSlice(t, got, expected)
+}
+
+/* ------------------------------------------------------------------ */
+/* extractShortTitle                                                   */
+/* ------------------------------------------------------------------ */
+
+func TestExtractShortTitle_ProspectusFull(t *testing.T) {
+	title := "首次公开发行股票并在创业板上市招股说明书"
+	got := extractShortTitle(title)
+	if got != "招股说明书" {
+		t.Fatalf("expected '招股说明书', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_ProspectusIntent(t *testing.T) {
+	title := "首次公开发行股票招股意向书"
+	got := extractShortTitle(title)
+	if got != "招股意向书" {
+		t.Fatalf("expected '招股意向书', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_ListingNotice(t *testing.T) {
+	title := "北京证券交易所上市公告书"
+	got := extractShortTitle(title)
+	if got != "上市公告书" {
+		t.Fatalf("expected '上市公告书', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_IssueNotice(t *testing.T) {
+	title := "发行公告"
+	got := extractShortTitle(title)
+	if got != "发行公告" {
+		t.Fatalf("expected '发行公告', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_FallbackZhaoGu(t *testing.T) {
+	title := "某某公司招股书及发行方案"
+	got := extractShortTitle(title)
+	if got != "招股书" {
+		t.Fatalf("expected '招股书', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_NoKeyword(t *testing.T) {
+	title := "短期融资券发行公告"
+	// "发行公告" is in titleKeywords, so it should match
+	got := extractShortTitle(title)
+	if got != "发行公告" {
+		t.Fatalf("expected '发行公告', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_NoKeywordFallback(t *testing.T) {
+	title := "年度报告摘要"
+	got := extractShortTitle(title)
+	// no keywords match, title is short
+	if got != "年度报告摘要" {
+		t.Fatalf("expected '年度报告摘要', got %q", got)
+	}
+}
+
+func TestExtractShortTitle_LongNoKeyword(t *testing.T) {
+	title := "这是一个非常长的标题用来测试当标题中没有匹配任何关键词时的截断行为"
+	got := extractShortTitle(title)
+	runes := []rune(title)
+	expected := string(runes[:15])
+	if got != expected {
+		t.Fatalf("expected first 15 runes (%q), got %q", expected, got)
+	}
+}
+
+func TestExtractShortTitle_PriorityOrder(t *testing.T) {
+	// 同时包含"招股说明书"和"上市公告书" → 优先返回靠前的 "招股说明书"
+	title := "招股说明书及上市公告书"
+	got := extractShortTitle(title)
+	if got != "招股说明书" {
+		t.Fatalf("expected '招股说明书' (higher priority), got %q", got)
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* sanitizeFilename                                                    */
+/* ------------------------------------------------------------------ */
+
+func TestSanitizeFilename_Normal(t *testing.T) {
+	got := sanitizeFilename("300750_宁德时代_招股说明书_20180522")
+	if got != "300750_宁德时代_招股说明书_20180522" {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestSanitizeFilename_Slashes(t *testing.T) {
+	got := sanitizeFilename("a/b\\c")
+	if got != "a_b_c" {
+		t.Fatalf("expected 'a_b_c', got %q", got)
+	}
+}
+
+func TestSanitizeFilename_Colon(t *testing.T) {
+	got := sanitizeFilename("file:name")
+	if got != "file_name" {
+		t.Fatalf("expected 'file_name', got %q", got)
+	}
+}
+
+func TestSanitizeFilename_WindowsIllegal(t *testing.T) {
+	input := `test<value>with"chars|*?`
+	got := sanitizeFilename(input)
+	if strings.ContainsAny(got, `<>"|*?`) {
+		t.Fatalf("illegal chars should be replaced, got %q", got)
+	}
+}
+
+func TestSanitizeFilename_Newlines(t *testing.T) {
+	got := sanitizeFilename("line1\nline2\rline3")
+	if strings.Contains(got, "\n") || strings.Contains(got, "\r") {
+		t.Fatalf("newlines should be removed, got %q", got)
+	}
+}
+
+func TestSanitizeFilename_Tabs(t *testing.T) {
+	got := sanitizeFilename("col1\tcol2")
+	if strings.Contains(got, "\t") {
+		t.Fatalf("tabs should be replaced with space, got %q", got)
+	}
+	if !strings.Contains(got, " ") {
+		t.Fatalf("tab should become space, got %q", got)
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* buildFilename                                                       */
+/* ------------------------------------------------------------------ */
+
+func TestBuildFilename_Normal(t *testing.T) {
+	a := &cninfo.Announcement{
+		Title: "首次公开发行股票并在创业板上市招股说明书",
+		Date:  "20180522",
+	}
+	got := buildFilename("300750", "宁德时代", a)
+	expected := "300750_宁德时代_招股说明书_20180522.pdf"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestBuildFilename_NoDateButHasTime(t *testing.T) {
+	a := &cninfo.Announcement{
+		Title: "首次公开发行股票招股意向书",
+		// Date 为空，但 Time 有值（毫秒时间戳对应 2018-05-22）
+		Time: 1526947200000,
+	}
+	got := buildFilename("600036", "招商银行", a)
+	// 时间戳毫秒 / 1000 = unix 秒 → 以字符串形式入文件名
+	expected := "600036_招商银行_招股意向书"
+	if !strings.HasPrefix(got, expected) {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestBuildFilename_IllegalCharsInTitle(t *testing.T) {
+	// 标题中的非法字符不会影响文件名（extractShortTitle 返回固定关键词，不含非法字符）
+	a := &cninfo.Announcement{
+		Title: "某公司:招股说明书/修订版",
+		Date:  "20240101",
+	}
+	got := buildFilename("000001", "平安银行", a)
+	if strings.ContainsAny(got, `/:<>"|*?`) {
+		t.Fatalf("filename should not contain illegal chars, got %q", got)
+	}
+}
+
+func TestBuildFilename_NormalTitle(t *testing.T) {
+	a := &cninfo.Announcement{
+		Title: "北京证券交易所上市公告书",
+		Date:  "20231115",
+	}
+	got := buildFilename("830001", "某某生物", a)
+	expected := "830001_某某生物_上市公告书_20231115.pdf"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* filterValidPDFs                                                     */
+/* ------------------------------------------------------------------ */
+
+func makeAnnouncement(title, adjunctURL string, existFlag, invalidationFlag int) *cninfo.Announcement {
+	return &cninfo.Announcement{
+		Title:            title,
+		AdjunctURL:       adjunctURL,
+		ExistFlag:        existFlag,
+		InvalidationFlag: invalidationFlag,
+	}
+}
+
+func TestFilterValidPDFs_AllValid(t *testing.T) {
+	input := []*cninfo.Announcement{
+		makeAnnouncement("招股说明书", "/finalpage/a.pdf", 0, 0),
+		makeAnnouncement("上市公告书", "/finalpage/b.pdf", 0, 0),
+	}
+	got := filterValidPDFs(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 valid, got %d", len(got))
+	}
+}
+
+func TestFilterValidPDFs_ExistFlag(t *testing.T) {
+	input := []*cninfo.Announcement{
+		makeAnnouncement("招股说明书", "/finalpage/a.pdf", 0, 0),
+		makeAnnouncement("上市公告书", "/finalpage/b.pdf", 1, 0), // ExistFlag=1 应被过滤
+	}
+	got := filterValidPDFs(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 valid after existFlag filter, got %d", len(got))
+	}
+	if got[0].Title != "招股说明书" {
+		t.Fatalf("expected '招股说明书' to survive, got %q", got[0].Title)
+	}
+}
+
+func TestFilterValidPDFs_InvalidationFlag(t *testing.T) {
+	input := []*cninfo.Announcement{
+		makeAnnouncement("招股说明书", "/finalpage/a.pdf", 0, 0),
+		makeAnnouncement("旧版招股书", "/finalpage/b.pdf", 0, 1), // InvalidationFlag=1 应被过滤
+	}
+	got := filterValidPDFs(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 valid after invalidationFlag filter, got %d", len(got))
+	}
+}
+
+func TestFilterValidPDFs_EmptyAdjunctURL(t *testing.T) {
+	input := []*cninfo.Announcement{
+		makeAnnouncement("招股说明书", "/finalpage/a.pdf", 0, 0),
+		makeAnnouncement("无附件公告", "", 0, 0), // AdjunctURL 为空 → 无法下载 → 过滤
+	}
+	got := filterValidPDFs(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 valid after empty adjunctURL filter, got %d", len(got))
+	}
+}
+
+func TestFilterValidPDFs_MixedInvalid(t *testing.T) {
+	input := []*cninfo.Announcement{
+		makeAnnouncement("A", "/a.pdf", 0, 0),
+		makeAnnouncement("B", "/b.pdf", 1, 0), // existFlag
+		makeAnnouncement("C", "/c.pdf", 0, 1), // invalidationFlag
+		makeAnnouncement("D", "", 0, 0),       // empty adjunctURL
+		makeAnnouncement("E", "/e.pdf", 1, 1), // both flags
+	}
+	got := filterValidPDFs(input)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 valid, got %d", len(got))
+	}
+	if got[0].Title != "A" {
+		t.Fatalf("expected 'A' to survive, got %q", got[0].Title)
+	}
+}
+
+func TestFilterValidPDFs_Empty(t *testing.T) {
+	got := filterValidPDFs(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice for nil input, got %v", got)
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+func assertIntSlice(t *testing.T, got, expected []int) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("length mismatch: expected %v, got %v", expected, got)
+	}
+	for i := range got {
+		if got[i] != expected[i] {
+			t.Fatalf("at index %d: expected %d, got %d (full: expected %v, got %v)",
+				i, expected[i], got[i], expected, got)
+		}
+	}
+}

--- a/cmd/ipo/ipo.go
+++ b/cmd/ipo/ipo.go
@@ -6,6 +6,7 @@
 package ipo
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -44,6 +45,7 @@ func NewIPOCLI() *cobra.Command {
 		newListCmd(),
 		newCalendarCmd(),
 		newProspectusCmd(),
+		newDownloadCmd(),
 	)
 
 	return root
@@ -271,6 +273,44 @@ func newProspectusCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveStock 将用户输入（代码或名称）解析为标准 A 股代码 + cninfo orgId + 证券简称。
+func resolveStock(ctx context.Context, input string) (code, orgID, name string, err error) {
+	secs := sina.Search(ctx, input)
+	sec := firstAShare(secs)
+	if sec != nil {
+		code = sec.Code
+		name = sec.Name
+		var resolvedName string
+		var lookupErr error
+		orgID, resolvedName, lookupErr = cninfo.LookupOrgID(ctx, code)
+		if lookupErr != nil {
+			err = fmt.Errorf("查找 %s 的公司身份失败: %w", code, lookupErr)
+			return
+		}
+		if orgID == "" {
+			err = fmt.Errorf("查找 %s 的公司身份为空", code)
+			return
+		}
+		if resolvedName != "" {
+			name = resolvedName
+		}
+		return
+	}
+
+	// sina 没搜到 A 股，尝试把用户输入当作 A 股代码
+	code = sanitizeCode(input)
+	if !isACode(code) {
+		err = fmt.Errorf("未找到 %s 对应的 A 股代码，请确认代码无误", input)
+		return
+	}
+	orgID, name, err = cninfo.LookupOrgID(ctx, code)
+	if err != nil || orgID == "" {
+		err = fmt.Errorf("查找 %s 的公司身份失败: %w", code, err)
+		return
+	}
+	return
+}
+
 func runProspectus(cmd *cobra.Command, args []string) error {
 	code := args[0]
 	size, _ := cmd.Flags().GetInt("size")
@@ -285,34 +325,9 @@ func runProspectus(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	// 1. 用户输入可能是简写（名称或代码），先用 sina 搜索做代码 + 市场匹配。
-	// sina 返回结果可能含港股/A 股同名项，cninfo 仅收录 A 股，因此优先选 A 股。
-	var stockCode, orgID, secName string
-	secs := sina.Search(ctx, code)
-	sec := firstAShare(secs)
-	if sec != nil {
-		stockCode = sec.Code
-		secName = sec.Name
-		resolvedOrgID, resolvedName, err := cninfo.LookupOrgID(ctx, stockCode)
-		if err != nil {
-			return fmt.Errorf("查找 %s 的公司身份失败: %w", stockCode, err)
-		}
-		orgID = resolvedOrgID
-		if resolvedName != "" {
-			secName = resolvedName
-		}
-	} else {
-		// sina 没搜到 A 股，尝试把用户输入当作 A 股代码
-		stockCode = sanitizeCode(code)
-		if !isACode(stockCode) {
-			return fmt.Errorf("未找到 %s 对应的 A 股代码，请确认代码无误", code)
-		}
-		resolvedOrgID, resolvedName, err := cninfo.LookupOrgID(ctx, stockCode)
-		if err != nil || resolvedOrgID == "" {
-			return fmt.Errorf("查找 %s 的公司身份失败: %w", stockCode, err)
-		}
-		orgID = resolvedOrgID
-		secName = resolvedName
+	stockCode, orgID, secName, err := resolveStock(ctx, code)
+	if err != nil {
+		return err
 	}
 
 	stockParam := fmt.Sprintf("%s,%s", stockCode, orgID)

--- a/docs/ipo-prospectus-download.md
+++ b/docs/ipo-prospectus-download.md
@@ -1,0 +1,400 @@
+# IPO 招股书下载方案设计
+
+> 目标：为 `sec` CLI 增加**下载** IPO 招股说明书 PDF 的能力。
+> 状态：方案阶段（2026-07-09）
+> 关联：[research-ipo.md](./research-ipo.md) — IPO 功能调研文档
+
+---
+
+## 一、现状分析
+
+### 1.1 已有能力
+
+| 能力          | 命令/函数                                       | 说明                                                      |
+| ------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| 招股书列表    | `sec ipo prospectus <code>`                     | 列出指定股票的 IPO 相关公告（标题、日期、大小、PDF 链接） |
+| IPO 公告查询  | `cninfo.QueryIPOs(ctx, stockParam, size)`       | 从巨潮资讯查询 IPO 公告列表，含 PDF URL                   |
+| PDF 下载      | `cninfo.DownloadPDF(ctx, adjunctURL, destPath)` | 从巨潮 CDN 下载单个 PDF 到本地路径                        |
+| 年报 PDF 下载 | `sec bsd <code> -y 2024`                        | **已有参考实现**：下载年报 PDF 的完整命令                 |
+
+### 1.2 现有代码路径
+
+```
+cmd/ipo/ipo.go
+  └── runProspectus()            → 查询 + 列表渲染（无下载）
+  └── printProspectus()          → tablewriter 表格输出
+
+provider/cninfo/cninfo.go
+  └── QueryIPOs()                → 招股书公告查询
+  └── DownloadPDF()              → 单文件 PDF 下载（已可用）
+  └── resolvePDFURL()            → PDF 直链解析
+
+cmd/balancesheet/download.go     → sec bsd 参考实现
+  └── BalanceSheetDownloadHandler()
+```
+
+### 1.3 差距
+
+- `sec ipo prospectus` **只能看不能下**：用户看到了 PDF 链接，但没有下载功能
+- `cninfo.DownloadPDF()` 已经就绪，只需上层命令调用
+- 缺少：交互选择、批量下载、文件命名策略、断点续传/跳过已有
+
+---
+
+## 二、需求梳理
+
+### 2.1 核心场景
+
+| 场景           | 用户意图                                             | 优先级 |
+| -------------- | ---------------------------------------------------- | ------ |
+| 下载最新招股书 | `sec ipo download 300750` 下载宁德时代最新一份招股书 | P0     |
+| 下载全部招股书 | `sec ipo download 300750 --all` 下载该股所有招股书   | P0     |
+| 交互选择下载   | 列表展示后，用户输入序号选择要下载的文件             | P1     |
+| 批量下载       | 一次下载多只股票的招股书                             | P2     |
+| 港股招股书     | 通过 HKEX 下载港股招股书                             | P2     |
+| 美股招股书     | 通过 SEC EDGAR 下载 S-1/F-1                          | P3     |
+
+### 2.2 功能需求
+
+1. **下载招股书 PDF**：从巨潮资讯下载 A 股 IPO 招股说明书
+2. **灵活选择**：支持下载最新一份、全部、或交互选择
+3. **输出目录**：支持 `-o` 指定保存目录
+4. **文件命名**：规范的命名格式，包含代码、名称、日期
+5. **下载反馈**：显示下载进度、文件大小、保存路径
+6. **跳过已有**：文件已存在时自动跳过（或 --force 覆盖）
+
+---
+
+## 三、方案对比
+
+### 方案 A：在现有 `prospectus` 命令增加 `--download` 标志
+
+```
+sec ipo prospectus 300750 --download          # 下载最新的
+sec ipo prospectus 300750 --download --all    # 下载全部
+sec ipo prospectus 300750 --download -o ./pdfs
+```
+
+**优点**：
+
+- 改动最小，复用现有查询/展示逻辑
+- 用户只需记一个命令
+
+**缺点**：
+
+- 命令职责混杂（查询+下载）
+- `prospectus` 语义偏向"查看"，加上 `--download` 语义不够清晰
+- 无法支持交互选择（列表已经渲染完了才决定要下载）
+
+### 方案 B：新增 `sec ipo download` 子命令（推荐）
+
+```
+sec ipo download 300750                  # 下载最新一份
+sec ipo download 300750 --all            # 下载全部
+sec ipo download 300750 --index 1,3      # 下载指定序号
+sec ipo download 300750 -o ./pdfs        # 指定目录
+sec ipo download 300750 --dry-run        # 只看不下载
+```
+
+**优点**：
+
+- 职责清晰：`prospectus` 看、`download` 下
+- 符合现有模式：`sec balance-sheet` 看报表、`sec bsd` 下年报
+- 交互式选择自然（先展示列表，再让用户选）
+- 可以设置别名：`sec ipo dl`
+
+**缺点**：
+
+- 多一个子命令（但项目已有模式支持）
+
+### 方案 C：新增顶层命令 `sec ipod`（类似 `sec bsd`）
+
+```
+sec ipod 300750                  # 类似 sec bsd
+sec ipod 300750 --all
+```
+
+**优点**：
+
+- 与 `sec bsd` 完全对称
+
+**缺点**：
+
+- 顶层命令越来越多，不利于组织
+- `ipo` 已有命令组，放在组下更自然
+
+### 推荐：方案 B
+
+理由：
+
+1. 与现有 `sec ipo` 命令组内聚
+2. 职责单一，语义清晰
+3. 便于后续扩展（港股、美股招股书下载可加 `--market` 参数）
+
+---
+
+## 四、详细设计（方案 B）
+
+### 4.1 命令签名
+
+```
+sec ipo download <code> [flags]
+
+Aliases: dl, d
+
+Flags:
+  -n, --size int         查询公告数量 (default 30)
+  -o, --output-dir string   PDF 保存目录 (default "./")
+  -a, --all               下载查询到的所有招股书
+  -i, --index string      下载指定序号的公告 （如 "1,3,5")
+      --force             覆盖已存在的文件
+      --dry-run           仅列出，不下载
+      --since string      起始日期 (YYYY-MM-DD)
+      --until string      截止日期 (YYYY-MM-DD)
+  -D, --debug             启用调试日志
+```
+
+### 4.2 交互流程
+
+```
+$ sec ipo download 300750
+
+宁德时代 (300750) IPO 相关公告 （来源：巨潮资讯）:
+
+  #  公告日期      公告标题                                    大小
+  1  2018-05-22   首次公开发行股票并在创业板上市招股说明书       12.5 MB
+  2  2018-05-22   首次公开发行股票并在创业板上市公告书           3.2 MB
+  3  2018-06-08   首次公开发行股票并在创业板上市之上市公告书     2.8 MB
+
+请选择要下载的编号 (all=全部，q=退出，默认=1): _
+```
+
+- 默认行为（无 `--all` / `--index` / `--dry-run`）：显示列表并交互选择
+- `--all`：跳过交互，直接下载全部
+- `--index 1,3`：跳过交互，下载指定编号
+- `--dry-run`：只显示列表不下载（相当于现有 `prospectus` 但加上编号）
+
+### 4.3 文件命名策略
+
+```
+格式：{code}_{name}_{title_short}_{date}.pdf
+
+示例：
+  300750_宁德时代_招股说明书_20180522.pdf
+  300750_宁德时代_上市公告书_20180608.pdf
+  600036_招商银行_招股意向书_20020322.pdf
+```
+
+命名规则：
+
+- `code`：6 位股票代码
+- `name`：证券简称
+- `title_short`：从公告标题提取关键词（招股说明书 / 招股意向书 / 上市公告书），长度 ≤20 字符
+- `date`：公告日期 YYYYMMDD
+
+### 4.4 下载输出
+
+```
+$ sec ipo download 300750
+
+宁德时代 (300750) IPO 相关公告 （来源：巨潮资讯）:
+
+  #  公告日期      公告标题                                    大小
+  1  2018-05-22   首次公开发行股票并在创业板上市招股说明书       12.5 MB
+  2  2018-05-22   首次公开发行股票并在创业板上市公告书           3.2 MB
+
+请选择要下载的编号 (all=全部，q=退出，默认=1): 1
+
+下载中。..
+  [1/1] 300750_宁德时代_招股说明书_20180522.pdf ... 12.5 MB ✓
+
+已保存至：./300750_宁德时代_招股说明书_20180522.pdf
+```
+
+### 4.5 跳过已有文件
+
+```
+$ sec ipo download 300750 --all
+
+  [1/2] 300750_宁德时代_招股说明书_20180522.pdf ... 已存在，跳过
+  [2/2] 300750_宁德时代_上市公告书_20180608.pdf ... 3.2 MB ✓
+
+下载完成：1 新下载，1 跳过，0 失败
+```
+
+使用 `--force` 覆盖已存在的文件。
+
+---
+
+## 五、代码结构设计
+
+### 5.1 文件变更
+
+```
+新增文件：
+  cmd/ipo/download.go          # download 子命令 + runDownload handler
+
+修改文件：
+  cmd/ipo/ipo.go               # NewIPOCLI() 中注册 download 子命令
+  provider/cninfo/cninfo.go     # 无需修改（已满足需求）
+  CHANGELOG.md                  # 记录新功能
+
+可选优化：
+  cmd/ipo/ipo.go               # 提取公共函数 (resolveStockCode 等） 供 prospectus 和 download 共用
+```
+
+### 5.2 核心数据结构
+
+```go
+// downloadConfig holds the parsed download options.
+type downloadConfig struct {
+    code      string   // 股票代码（用户输入）
+    size      int      // 查询条数
+    outputDir string   // 输出目录
+    all       bool     // 下载全部
+    index     []int    // 指定序号（1-based）
+    force     bool     // 覆盖已有
+    dryRun    bool     // 仅预览
+    since     string   // 起始日期
+    until     string   // 截止日期
+}
+```
+
+### 5.3 核心函数签名
+
+```go
+// cmd/ipo/download.go
+
+func newDownloadCmd() *cobra.Command
+func runDownload(cmd *cobra.Command, args []string) error
+
+// 交互选择
+func promptSelection(out io.Writer, in io.Reader, max int) ([]int, error)
+
+// 文件名生成
+func buildFilename(code, name string, a *cninfo.Announcement) string
+
+// 标题关键词提取
+func extractShortTitle(title string) string
+
+// 公告过滤（复用现有 filterByDate）
+```
+
+### 5.4 公共函数提取（可选优化）
+
+`runProspectus` 和 `runDownload` 共享的步骤可提取：
+
+```go
+// resolveStock 将用户输入解析为标准 A 股代码 + orgId + 名称
+func resolveStock(ctx context.Context, input string) (code, orgID, name string, err error)
+```
+
+提取后可减少 `download.go` 与 `prospectus` 的重复代码。
+
+---
+
+## 六、实现计划
+
+### Phase 1: MVP（P0）
+
+| 步骤 | 内容                                            | 预估   |
+| ---- | ----------------------------------------------- | ------ |
+| 1    | 提取 `resolveStock()` 公共函数                  | 10 min |
+| 2    | 在 `cmd/ipo/ipo.go` 注册 `download` 子命令      | 5 min  |
+| 3    | 实现 `cmd/ipo/download.go`：查询 + 默认交互下载 | 30 min |
+| 4    | 实现 `--all` 和 `--index` 模式                  | 15 min |
+| 5    | 实现 `--output-dir` / `--force` / `--dry-run`   | 15 min |
+| 6    | `go fmt` + 编译测试 + 手动验证                  | 15 min |
+| 7    | 更新 CHANGELOG.md                               | 5 min  |
+
+**Phase 1 总预估：~1.5 小时**
+
+### Phase 2: 增强（P1）
+
+| 步骤 | 内容                                        |
+| ---- | ------------------------------------------- |
+| 1    | 使用 `progressbar` 库显示下载进度条         |
+| 2    | 支持 `--concurrency` 并发下载               |
+| 3    | 交互式 TUI（使用 bubbletea 或简单终端交互） |
+
+### Phase 3: 港股 + 美股（P2-P3）
+
+| 步骤 | 内容                                             |
+| ---- | ------------------------------------------------ |
+| 1    | `provider/hkex/prospectus.go` — HKEX 招股书查询  |
+| 2    | `provider/sec/edgar.go` — SEC EDGAR S-1/F-1 查询 |
+| 3    | `--market hk` / `--market us` 参数支持           |
+
+---
+
+## 七、风险与注意事项
+
+| 风险                                | 缓解措施                                                 |
+| ----------------------------------- | -------------------------------------------------------- | --------------------------- |
+| 巨潮 PDF URL 带权限/token 过期      | 下载前重新解析 URL（`resolvePDFURL` 实时计算）           |
+| PDF 文件较大（招股书可达 30-50 MB） | `cninfo.DownloadPDF` 已有 10min 超时；下载时显示文件大小 |
+| 巨潮请求频率限制                    | `download --all` 时每个请求间隔 2-3 秒                   |
+| 文件名过长（标题超长）              | `extractShortTitle` 限制 ≤20 字符                        |
+| 文件名含非法字符                    | 过滤 `/\:\*?"<>                                          | ` 等 Windows/macOS 非法字符 |
+| 网络中断导致半截文件                | 先下载到临时文件（`.tmp` 后缀），完成后再 rename         |
+
+---
+
+## 八、完整命令示例
+
+```bash
+# 交互下载（默认行为）
+sec ipo download 300750
+
+# 下载最新一份（默认=1，无需交互）
+sec ipo download 300750 --index 1
+
+# 下载指定序号的
+sec ipo download 300750 -i 1,3,5
+
+# 下载全部
+sec ipo download 300750 --all
+
+# 指定输出目录
+sec ipo download 300750 -o ~/Documents/招股书/
+
+# 覆盖已有
+sec ipo download 300750 --all --force
+
+# 预览模式（看看有什么可下载）
+sec ipo download 300750 --dry-run
+
+# 日期范围过滤后下载
+sec ipo download 300750 --since 2018-01-01 --until 2018-12-31 --all
+
+# 别名
+sec ipo dl 300750
+sec ipo d 300750
+```
+
+---
+
+## 九、与其他命令的关系
+
+```
+sec ipo list            → 查看 IPO 上市列表（来自东方财富）
+sec ipo calendar        → 查看 IPO 排期/日历（来自巨潮资讯）
+sec ipo prospectus      → 查看某股的招股书列表（来自巨潮资讯）
+sec ipo download  ←NEW → 下载某股的招股书 PDF（来自巨潮资讯）
+sec bsd                 → 下载某股的年报 PDF（对比参考）
+```
+
+---
+
+## 十、总结
+
+**推荐方案 B**：在 `sec ipo` 命令组下新增 `download` 子命令。
+
+核心思路：
+
+1. 复用现有 `cninfo.QueryIPOs()` + `cninfo.DownloadPDF()` 能力
+2. 参考 `sec bsd` 的下载命令模式
+3. 支持交互选择 + 命令行参数两种使用方式
+4. Phase 1 聚焦 A 股 MVP，Phase 2-3 扩展港股/美股
+
+实施成本低（~1.5h），代码改动集中在 `cmd/ipo/` 包内，不涉及 provider 层变更。


### PR DESCRIPTION
### v0.3.11

1. 新增 `sec ipo download` 命令：支持交互选择、批量下载、指定编号下载招股说明书 PDF
2. 数据来源：巨潮资讯 cninfo（复用 `cninfo.QueryIPOs` + `cninfo.DownloadPDF`）
3. 提取 `resolveStock` 公共函数，供 `prospectus` 和 `download` 命令共用
4. 支持 `--all`（全部下载）、`--index`（指定编号）、`--force`（覆盖已有）、`--dry-run`（预览）、`-o`（输出目录）等参数


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sec ipo download` to download CNINFO prospectus PDFs with interactive selection or `--all/--index`, `--dry-run`, date filtering (`--since/--until`), output directory control, and overwrite behavior (`--force`).
  * Improved stock input resolution for more reliable CNINFO lookup.
* **Bug Fixes**
  * Safer, filesystem-friendly filename generation and more predictable handling of existing files.
* **Tests**
  * Added unit tests covering selection, index parsing, title/filename logic, and PDF candidate filtering.
* **Documentation**
  * Added `ipo-prospectus-download` documentation and updated the changelog for v0.3.11.
* **Chores**
  * Expanded local permission allowlist for needed Go tooling commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->